### PR TITLE
Revert "Deprecate openshift/knative-serving (#1278)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# This repository is deprecated. Use [`https://github.com/openshift-knative/serving`](https://github.com/openshift-knative/serving)
-
 # Openshift Knative Serving
 
 This repository holds Openshift's fork of


### PR DESCRIPTION
- This reverts commit 48f3adefe7ca99f1f63524250cb1ff846b6ebe2a.
- This repo is the new one.