### PR TITLE
Fix minimum version patch

### DIFF
--- a/openshift/patches/005-k8s-min.patch
+++ b/openshift/patches/005-k8s-min.patch
@@ -6,7 +6,7 @@ index 39e34464b..c79f442de 100644
  	// NOTE: If you are changing this line, please also update the minimum kubernetes
  	// version listed here:
  	// https://github.com/knative/docs/blob/mkdocs/docs/snippets/prerequisites.md
--	defaultMinimumVersion = "v1.23.0"
+-	defaultMinimumVersion = "v1.24.0"
 +	defaultMinimumVersion = "v1.19.0"
  )
  


### PR DESCRIPTION
- Fix failure here: https://master-jenkins-csb-serverless-qe.apps.ocp-c1.prod.psi.redhat.com/job/ci/job/knative-nightly-ci-serving/579/console. Upstream version ahs moved to [1.24.0](https://github.com/knative/serving/blob/main/vendor/knative.dev/pkg/version/version.go#L36).