### PR TITLE
[RELEASE-v1.8] Drop SeccompProfile from deployment

### DIFF
--- a/openshift/patches/008-remove-seccomp-queue.patch
+++ b/openshift/patches/008-remove-seccomp-queue.patch
@@ -1,0 +1,14 @@
+diff --git a/pkg/reconciler/revision/resources/queue.go b/pkg/reconciler/revision/resources/queue.go
+index 29ac1db50..fc4178433 100644
+--- a/pkg/reconciler/revision/resources/queue.go
++++ b/pkg/reconciler/revision/resources/queue.go
+@@ -87,9 +87,6 @@ var (
+ 		Capabilities: &corev1.Capabilities{
+ 			Drop: []corev1.Capability{"ALL"},
+ 		},
+-		SeccompProfile: &corev1.SeccompProfile{
+-			Type: corev1.SeccompProfileTypeRuntimeDefault,
+-		},
+ 	}
+ )
+ 

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -87,9 +87,6 @@ var (
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},
 		},
-		SeccompProfile: &corev1.SeccompProfile{
-			Type: corev1.SeccompProfileTypeRuntimeDefault,
-		},
 	}
 )
 


### PR DESCRIPTION
This patch cherry-pick https://github.com/openshift/knative-serving/pull/1287 for release-v1.8.

/cc @skonto @mgencur 