### PR TITLE
[MAIN] Upgrade to v1beta1

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -206,7 +206,7 @@ function install_knative(){
 
   # Install Knative Serving with initial values in test/config/config-observability.yaml.
   cat <<-EOF | oc apply -f - || return $?
-apiVersion: operator.knative.dev/v1alpha1
+apiVersion: operator.knative.dev/v1beta1
 kind: KnativeServing
 metadata:
   name: knative-serving


### PR DESCRIPTION
- Switched to v1beta1 in https://github.com/openshift-knative/serverless-operator/commit/5d6c2957660e4d1bba5647143b2e27bced4bd189. So there is no v1alpha1 any more.
- Failures seen in #33 

>  oc apply -f -
error: unable to recognize "STDIN": no matches for kind "KnativeServing" in version "operator.knative.dev/v1alpha1"