### PR TITLE
[RELEASE-v1.8] Run openshift/release/resolve.sh

### DIFF
--- a/openshift/release/knative-serving-ci.yaml
+++ b/openshift/release/knative-serving-ci.yaml
@@ -5702,7 +5702,7 @@ data:
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: autoscaling/v2
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: activator

--- a/openshift/release/knative-serving-knative-v1.8.0.yaml
+++ b/openshift/release/knative-serving-knative-v1.8.0.yaml
@@ -5702,7 +5702,7 @@ data:
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: autoscaling/v2
+apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
   name: activator


### PR DESCRIPTION
This patch just runs `openshift/release/resolve.sh` and updates ci manifests.

It missed to run after https://github.com/openshift-knative/serving/pull/8

/cc @skonto @mgencur 