### PR TITLE
Remove upstream workflows from nightly sync

### DIFF
--- a/openshift/release/update-to-head.sh
+++ b/openshift/release/update-to-head.sh
@@ -16,6 +16,10 @@ openshift/release/mirror-upstream-branches.sh
 git fetch upstream main
 git checkout upstream/main -B ${REPO_BRANCH}
 
+# Remove GH Action hooks from upstream
+rm -rf .github/workflows
+git commit -sm ":fire: remove unneeded workflows" .github/
+
 # Update openshift's main and take all needed files from there.
 git fetch openshift main
 git checkout openshift/main openshift OWNERS_ALIASES OWNERS Makefile


### PR DESCRIPTION
The workflows should be removed in the same way as in create-release-branch.sh so that they're not executed when pushing to release-next and release-next-ci branches.