### PR TITLE
[RELEASE-1.6] [BACKPORT] Fix drainer nil pointer

### DIFF
--- a/vendor/knative.dev/pkg/network/handlers/drain.go
+++ b/vendor/knative.dev/pkg/network/handlers/drain.go
@@ -196,7 +196,7 @@ func (d *Drainer) resetTimer() {
 
 	d.Lock()
 	defer d.Unlock()
-	if d.timer.Stop() {
+	if d.timer != nil && d.timer.Stop() {
 		d.timer.Reset(d.QuietPeriod)
 	}
 }


### PR DESCRIPTION
- Backport of https://github.com/knative/pkg/pull/2645.
- Patched upstream versions: 1.7, 1.8. We need this in <1.7 because we backported the new drainer logic to earlier versions.