### PR TITLE
Use nonroot distroless base image for the "runtime" test image

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,4 +1,5 @@
 # Use :nonroot base image for all containers
 defaultBaseImage: registry.access.redhat.com/ubi8/ubi-minimal:latest
 baseImageOverrides:
+  knative.dev/serving/test/test_images/runtime: gcr.io/distroless/static:nonroot
   knative.dev/serving/vendor/github.com/tsenart/vegeta/v12: ubuntu:latest


### PR DESCRIPTION
The runtime image needs to run with non-root user 65532. The Serving test suite depends on it.