### PR TITLE
[WIP] [RELEASE-1.6][SRVKS-985] Add revision security defaults

### DIFF
--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "23732fd7"
+    knative.dev/example-checksum: "e9899202"
 data:
   _example: |-
     ################################
@@ -39,6 +39,13 @@ data:
     # These sample configuration options may be copied out of
     # this example block and unindented to be in the data block
     # to actually change the configuration.
+
+    # Default SecurityContext settings to secure-by-default values
+    # if unset.
+    #
+    # This value will default to "enabled" in a future release,
+    # probably Knative 1.9
+    secure-pod-defaults: "disabled"
 
     # Indicates whether multi container support is enabled
     #

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -218,6 +218,7 @@ spec:
   config:
     features:
       secure-pod-defaults: "enabled"
+      kubernetes.containerspec-addcapabilities: "enabled"
     deployment:
       progressDeadline: "120s"
     observability:

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -216,6 +216,8 @@ spec:
     kourier:
       service-type: "LoadBalancer" # To enable gRPC and HTTP2 tests without OCP Route.
   config:
+    features:
+      secure-pod-defaults: "enabled"
     deployment:
       progressDeadline: "120s"
     observability:

--- a/openshift/release/artifacts/2-serving-core.yaml
+++ b/openshift/release/artifacts/2-serving-core.yaml
@@ -4892,7 +4892,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: "1.6.0"
   annotations:
-    knative.dev/example-checksum: "433d7e74"
+    knative.dev/example-checksum: "e9899202"
 data:
   _example: |-
     ################################
@@ -4909,6 +4909,13 @@ data:
     # These sample configuration options may be copied out of
     # this example block and unindented to be in the data block
     # to actually change the configuration.
+
+    # Default SecurityContext settings to secure-by-default values
+    # if unset.
+    #
+    # This value will default to "enabled" in a future release,
+    # probably Knative 1.9
+    secure-pod-defaults: "disabled"
 
     # Indicates whether multi container support is enabled
     #
@@ -4979,6 +4986,7 @@ data:
     # - RunAsNonRoot
     # - SupplementalGroups
     # - RunAsUser
+    # - SeccompProfile
     #
     # This feature flag should be used with caution as the PodSecurityContext
     # properties may have a side-effect on non-user sidecar containers that come

--- a/openshift/release/download_release_artifacts.sh
+++ b/openshift/release/download_release_artifacts.sh
@@ -53,3 +53,6 @@ git apply "${manifest_path}/003-serving-pdb.patch"
 
 # Add psp patch.
 git apply "${manifest_path}/005-psp.patch"
+
+# Add secure-pod-defaults config option.
+git apply "${manifest_path}/006-secure-pod-defaults.patch"

--- a/openshift/release/knative-serving-ci.yaml
+++ b/openshift/release/knative-serving-ci.yaml
@@ -4892,7 +4892,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: "v1.2.0"
   annotations:
-    knative.dev/example-checksum: "433d7e74"
+    knative.dev/example-checksum: "e9899202"
 data:
   _example: |-
     ################################
@@ -4909,6 +4909,13 @@ data:
     # These sample configuration options may be copied out of
     # this example block and unindented to be in the data block
     # to actually change the configuration.
+
+    # Default SecurityContext settings to secure-by-default values
+    # if unset.
+    #
+    # This value will default to "enabled" in a future release,
+    # probably Knative 1.9
+    secure-pod-defaults: "disabled"
 
     # Indicates whether multi container support is enabled
     #
@@ -4979,6 +4986,7 @@ data:
     # - RunAsNonRoot
     # - SupplementalGroups
     # - RunAsUser
+    # - SeccompProfile
     #
     # This feature flag should be used with caution as the PodSecurityContext
     # properties may have a side-effect on non-user sidecar containers that come

--- a/openshift/release/manifest-patches/006-secure-pod-defaults.patch
+++ b/openshift/release/manifest-patches/006-secure-pod-defaults.patch
@@ -1,0 +1,35 @@
+diff --git a/openshift/release/artifacts/2-serving-core.yaml b/openshift/release/artifacts/2-serving-core.yaml
+index f384d2494..b7ad7232a 100644
+--- a/openshift/release/artifacts/2-serving-core.yaml
++++ b/openshift/release/artifacts/2-serving-core.yaml
+@@ -4892,7 +4892,7 @@ metadata:
+     app.kubernetes.io/component: controller
+     app.kubernetes.io/version: "1.6.0"
+   annotations:
+-    knative.dev/example-checksum: "433d7e74"
++    knative.dev/example-checksum: "e9899202"
+ data:
+   _example: |-
+     ################################
+@@ -4910,6 +4910,13 @@ data:
+     # this example block and unindented to be in the data block
+     # to actually change the configuration.
+
++    # Default SecurityContext settings to secure-by-default values
++    # if unset.
++    #
++    # This value will default to "enabled" in a future release,
++    # probably Knative 1.9
++    secure-pod-defaults: "disabled"
++
+     # Indicates whether multi container support is enabled
+     #
+     # WARNING: Cannot safely be disabled once enabled.
+@@ -4979,6 +4986,7 @@ data:
+     # - RunAsNonRoot
+     # - SupplementalGroups
+     # - RunAsUser
++    # - SeccompProfile
+     #
+     # This feature flag should be used with caution as the PodSecurityContext
+     # properties may have a side-effect on non-user sidecar containers that come

--- a/pkg/apis/config/features.go
+++ b/pkg/apis/config/features.go
@@ -60,6 +60,7 @@ func defaultFeaturesConfig() *Features {
 		PodSpecInitContainers:            Disabled,
 		PodSpecDNSPolicy:                 Disabled,
 		PodSpecDNSConfig:                 Disabled,
+		SecurePodDefaults:                Disabled,
 		TagHeaderBasedRouting:            Disabled,
 		AutoDetectHTTP2:                  Disabled,
 	}
@@ -89,6 +90,7 @@ func NewFeaturesConfigFromMap(data map[string]string) (*Features, error) {
 		asFlag("kubernetes.podspec-persistent-volume-write", &nc.PodSpecPersistentVolumeWrite),
 		asFlag("kubernetes.podspec-dnspolicy", &nc.PodSpecDNSPolicy),
 		asFlag("kubernetes.podspec-dnsconfig", &nc.PodSpecDNSConfig),
+		asFlag("secure-pod-defaults", &nc.SecurePodDefaults),
 		asFlag("tag-header-based-routing", &nc.TagHeaderBasedRouting),
 		asFlag("autodetect-http2", &nc.AutoDetectHTTP2)); err != nil {
 		return nil, err
@@ -122,6 +124,7 @@ type Features struct {
 	PodSpecPersistentVolumeWrite     Flag
 	PodSpecDNSPolicy                 Flag
 	PodSpecDNSConfig                 Flag
+	SecurePodDefaults                Flag
 	TagHeaderBasedRouting            Flag
 	AutoDetectHTTP2                  Flag
 }

--- a/pkg/apis/config/features_test.go
+++ b/pkg/apis/config/features_test.go
@@ -72,6 +72,7 @@ func TestFeaturesConfiguration(t *testing.T) {
 			PodSpecSchedulerName:             Enabled,
 			PodSpecDNSPolicy:                 Enabled,
 			PodSpecDNSConfig:                 Enabled,
+			SecurePodDefaults:                Enabled,
 			TagHeaderBasedRouting:            Enabled,
 		}),
 		data: map[string]string{
@@ -88,6 +89,7 @@ func TestFeaturesConfiguration(t *testing.T) {
 			"kubernetes.podspec-schedulername":             "Enabled",
 			"kubernetes.podspec-dnspolicy":                 "Enabled",
 			"kubernetes.podspec-dnsconfig":                 "Enabled",
+			"secure-pod-defaults":                          "Enabled",
 			"tag-header-based-routing":                     "Enabled",
 		},
 	}, {

--- a/pkg/apis/serving/v1/revision_defaults.go
+++ b/pkg/apis/serving/v1/revision_defaults.go
@@ -72,6 +72,10 @@ func (rs *RevisionSpec) SetDefaults(ctx context.Context) {
 	applyDefaultContainerNames(rs.PodSpec.InitContainers, containerNames, defaultInitContainerName)
 	for idx := range rs.PodSpec.Containers {
 		rs.applyDefault(ctx, &rs.PodSpec.Containers[idx], cfg)
+		rs.defaultSecurityContext(rs.PodSpec.SecurityContext, &rs.PodSpec.Containers[idx], cfg)
+	}
+	for idx := range rs.PodSpec.InitContainers {
+		rs.defaultSecurityContext(rs.PodSpec.SecurityContext, &rs.PodSpec.InitContainers[idx], cfg)
 	}
 }
 
@@ -180,5 +184,57 @@ func applyDefaultContainerNames(containers []corev1.Container, containerNames se
 
 			containers[idx].Name = name
 		}
+	}
+}
+
+func (rs *RevisionSpec) defaultSecurityContext(psc *corev1.PodSecurityContext, container *corev1.Container, cfg *config.Config) {
+	if cfg.Features.SecurePodDefaults != config.Enabled {
+		return
+	}
+
+	if psc == nil {
+		psc = &corev1.PodSecurityContext{}
+	}
+
+	updatedSC := container.SecurityContext
+
+	if updatedSC == nil {
+		updatedSC = &corev1.SecurityContext{}
+	}
+
+	if updatedSC.AllowPrivilegeEscalation == nil {
+		updatedSC.AllowPrivilegeEscalation = ptr.Bool(false)
+	}
+
+	//if psc.SeccompProfile == nil || psc.SeccompProfile.Type == "" {
+	//	if updatedSC.SeccompProfile == nil {
+	//		updatedSC.SeccompProfile = &corev1.SeccompProfile{}
+	//	}
+	//	if updatedSC.SeccompProfile.Type == "" {
+	//		updatedSC.SeccompProfile.Type = corev1.SeccompProfileTypeRuntimeDefault
+	//	}
+	//}
+	if updatedSC.Capabilities == nil {
+		updatedSC.Capabilities = &corev1.Capabilities{}
+	}
+	if updatedSC.Capabilities.Drop == nil {
+		updatedSC.Capabilities.Drop = []corev1.Capability{"ALL"}
+		// Default in NET_BIND_SERVICE to allow binding to low-numbered ports.
+		needsLowPort := false
+		for _, p := range container.Ports {
+			if p.ContainerPort < 1024 {
+				needsLowPort = true
+				break
+			}
+		}
+		if updatedSC.Capabilities.Add == nil && needsLowPort {
+			updatedSC.Capabilities.Add = []corev1.Capability{"NET_BIND_SERVICE"}
+		}
+	}
+	if psc.RunAsNonRoot == nil && updatedSC.RunAsNonRoot == nil {
+		updatedSC.RunAsNonRoot = ptr.Bool(true)
+	}
+	if *updatedSC != (corev1.SecurityContext{}) {
+		container.SecurityContext = updatedSC
 	}
 }

--- a/pkg/apis/serving/v1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1/revision_defaults_test.go
@@ -835,6 +835,201 @@ func TestRevisionDefaulting(t *testing.T) {
 				},
 			},
 		},
+	}, {
+		name: "Default security context with feature enabled",
+		wc: func(ctx context.Context) context.Context {
+			s := config.NewStore(logger)
+			s.OnConfigChanged(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: autoscalerconfig.ConfigName}})
+			s.OnConfigChanged(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: config.DefaultsConfigName}})
+			s.OnConfigChanged(
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: config.FeaturesConfigName},
+					Data:       map[string]string{"secure-pod-defaults": "Enabled"},
+				},
+			)
+
+			return s.ToContext(ctx)
+		},
+		in: &Revision{
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "user-container",
+						Ports: []corev1.ContainerPort{{
+							ContainerPort: 80,
+						}},
+					}, {
+						Name:            "sidecar",
+						SecurityContext: &corev1.SecurityContext{},
+					}, {
+						Name: "special-sidecar",
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.Bool(true),
+							Capabilities: &corev1.Capabilities{
+								Add:  []corev1.Capability{"NET_ADMIN"},
+								Drop: []corev1.Capability{},
+							},
+						},
+					}},
+					InitContainers: []corev1.Container{{
+						Name: "special-init",
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.Bool(true),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type:             corev1.SeccompProfileTypeLocalhost,
+								LocalhostProfile: ptr.String("special"),
+							},
+							Capabilities: &corev1.Capabilities{
+								Add: []corev1.Capability{"NET_ADMIN"},
+							},
+						},
+					}},
+				},
+			},
+		},
+		want: &Revision{
+			Spec: RevisionSpec{
+				ContainerConcurrency: ptr.Int64(config.DefaultContainerConcurrency),
+				TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "user-container",
+						Ports: []corev1.ContainerPort{{
+							ContainerPort: 80,
+						}},
+						ReadinessProbe: defaultProbe,
+						Resources:      defaultResources,
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							//SeccompProfile: &corev1.SeccompProfile{
+							//	Type: corev1.SeccompProfileTypeRuntimeDefault,
+							//},
+							RunAsNonRoot: ptr.Bool(true),
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+								Add:  []corev1.Capability{"NET_BIND_SERVICE"},
+							},
+						},
+					}, {
+						Name:      "sidecar",
+						Resources: defaultResources,
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							//SeccompProfile: &corev1.SeccompProfile{
+							//	Type: corev1.SeccompProfileTypeRuntimeDefault,
+							//},
+							RunAsNonRoot: ptr.Bool(true),
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+						},
+					}, {
+						Name:      "special-sidecar",
+						Resources: defaultResources,
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.Bool(true),
+							//SeccompProfile: &corev1.SeccompProfile{
+							//	Type: corev1.SeccompProfileTypeRuntimeDefault,
+							//},
+							RunAsNonRoot: ptr.Bool(true),
+							Capabilities: &corev1.Capabilities{
+								Add:  []corev1.Capability{"NET_ADMIN"},
+								Drop: []corev1.Capability{},
+							},
+						},
+					}},
+					InitContainers: []corev1.Container{{
+						Name: "special-init",
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.Bool(true),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type:             corev1.SeccompProfileTypeLocalhost,
+								LocalhostProfile: ptr.String("special"),
+							},
+							RunAsNonRoot: ptr.Bool(true),
+							Capabilities: &corev1.Capabilities{
+								Add:  []corev1.Capability{"NET_ADMIN"},
+								Drop: []corev1.Capability{"ALL"},
+							},
+						},
+					}},
+				},
+			},
+		},
+	}, {
+		name: "uses pod defaults in security context",
+		wc: func(ctx context.Context) context.Context {
+			s := config.NewStore(logger)
+			s.OnConfigChanged(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: autoscalerconfig.ConfigName}})
+			s.OnConfigChanged(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: config.DefaultsConfigName}})
+			s.OnConfigChanged(
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: config.FeaturesConfigName},
+					Data:       map[string]string{"secure-pod-defaults": "Enabled"},
+				},
+			)
+
+			return s.ToContext(ctx)
+		},
+		in: &Revision{
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "user-container",
+						Ports: []corev1.ContainerPort{{
+							ContainerPort: 8080,
+						}},
+					}},
+					InitContainers: []corev1.Container{{
+						Name:            "init",
+						SecurityContext: &corev1.SecurityContext{},
+					}},
+					SecurityContext: &corev1.PodSecurityContext{
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeUnconfined,
+						},
+					},
+				},
+			},
+		},
+		want: &Revision{
+			Spec: RevisionSpec{
+				ContainerConcurrency: ptr.Int64(config.DefaultContainerConcurrency),
+				TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "user-container",
+						Ports: []corev1.ContainerPort{{
+							ContainerPort: 8080,
+						}},
+						ReadinessProbe: defaultProbe,
+						Resources:      defaultResources,
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							RunAsNonRoot:             ptr.Bool(true),
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+						},
+					}},
+					InitContainers: []corev1.Container{{
+						Name: "init",
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							RunAsNonRoot:             ptr.Bool(true),
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+						},
+					}},
+					SecurityContext: &corev1.PodSecurityContext{
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeUnconfined,
+						},
+					},
+				},
+			},
+		},
 	}}
 
 	for _, test := range tests {

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -251,6 +251,21 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 		}
 	}
 
+	//if cfg.Features.SecurePodDefaults == apicfg.Enabled {
+	//	psc := rev.Spec.SecurityContext
+	//	if psc == nil {
+	//		psc = &corev1.PodSecurityContext{}
+	//	}
+	//	if psc.SeccompProfile == nil || psc.SeccompProfile.Type == "" {
+	//		if queueSecurityContext.SeccompProfile == nil {
+	//			queueSecurityContext.SeccompProfile = &corev1.SeccompProfile{}
+	//		}
+	//		if queueSecurityContext.SeccompProfile.Type == "" {
+	//			queueSecurityContext.SeccompProfile.Type = corev1.SeccompProfileTypeRuntimeDefault
+	//		}
+	//	}
+	//}
+
 	c := &corev1.Container{
 		Name:            QueueContainerName,
 		Image:           cfg.Deployment.QueueSidecarImage,


### PR DESCRIPTION
- Adapted from https://github.com/knative/serving/pull/13398
- The idea is to enable the feature by default at the S-O side on OCP 4.11+ as we did with deprecated apis.
- This sets everything as a default except for seccompProfile. Here is why.
  SeccompProfile on OCP filters certain syscalls: 
```  
In pod 3scale-kourier-gateway-56bfb7497f-lfjzm
    sh-4.4$  ./amicontained
    Container Runtime: kube
    Has Namespaces:
            pid: true
            user: false
    AppArmor Profile: system_u:system_r:container_t:s0:c9,c27
    Capabilities:
    Seccomp: filtering
    Blocked Syscalls (45):
            MSGRCV SYSLOG SETUID SETSID SETREUID SETGROUPS SETRESUID USELIB USTAT SYSFS VHANGUP PIVOT_ROOT CHROOT ACCT SETTIMEOFDAY UMOUNT2 SWAPON SWAPOFF REBOOT SETHOSTNAME SETDOMAINNAME IOPL IOPERM INIT_MODULE DELETE_MODULE QUERY_MODULE QUOTACTL NFSSERVCTL LOOKUP_DCOOKIE CLOCK_SETTIME KEXEC_LOAD MIGRATE_PAGES FUTIMESAT VMSPLICE MOVE_PAGES UTIMENSAT PE
```
This means TestShouldRunAsUserContainerDefault will not work. Tried it with the ksvc [here](https://gist.github.com/skonto/5ae4a3b51de98e9bebc6226bfa312e65).
The downside here is that we still see the warning in the controller (other fields are fine) : 
```
{"severity":"WARNING","timestamp":"2022-12-05T22:08:11.415195138Z","logger":"controller","caller":"logging/warning_handler.go:32","message":"API Warning: would violate PodSecurity \"restricted:v1.24\": seccompProfile (pod or containers \"user-container\", \"queue-proxy\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")","commit":"8835ff5","knative.dev/pod":"controller-6ff988dcc4-txvz8"}
```

The warning seems weird (invalid?) because it is reported [here ](https://github.com/redhat-openshift-ecosystem/community-operators-prod/discussions/1417) that:

 ```
V2 requires you to either leave SeccompProfile empty or set it to runtime/default
** Empty is compatible with v1 and works on OCP versions < 4.11
```
For this PR using `runAsUser` works as expected by setting:
`oc adm policy add-scc-to-user anyuid -z default -n {ns}` if there is no label `pod-security.kubernetes.io/enforce=restricted`. Tested with [ksvc](https://gist.github.com/skonto/07ae76703aaa8997cb0064501d369335) and by executin `id` in pod's containers.

If such a namespace label exists then user [needs to set](https://docs.openshift.com/dedicated/authentication/managing-security-context-constraints.html): `oc adm policy add-scc-to-user nonroot-v2 -z default -n {ns}`
- In case we choose to eliminate all warnings by setting seccompProfile too by default we will have somehow to label a revision with a special key/pair to be able to skip it in scenarios like TestShouldRunAsUserContainerDefault. 
 That would deviate from unfinished upstream work and also would require docs for that case.
However even if we set all fields we still get a different warning because seccompProfile is not available in crds:

```
{"severity":"WARNING","timestamp":"2022-12-05T14:54:55.718187034Z","logger":"controller","caller":"logging/warning_handler.go:32","message":"API Warning: unknown field \"spec.template.spec.containers[0].securityContext.seccompProfile\"","commit":"8835ff5","knative.dev/pod":"controller-c98d8498c-schv6"}
```
- I also tried `unconfined` or "" for the seccompProfile as defined [here](https://github.com/kubernetes/cri-api/blob/master/pkg/apis/runtime/v1/api.proto#L348) (trying to figure out what empty means and it was supposed to be turned into runtime/default on OCP but it does not work or I am missing something):

```
LAST SEEN   TYPE      REASON            OBJECT                         MESSAGE
3s          Warning   InternalError     revision/helloworld-go-00001   failed to create deployment "helloworld-go-00001-deployment": Deployment.apps "helloworld-go-00001-deployment" is invalid: [spec.template.spec.containers[0].securityContext.seccompProfile.type: Required value: type is required when seccompProfile is set, spec.template.spec.containers[1].securityContext.seccompProfile.type: Required value: type is required when seccompProfile is set]
```