### PR TITLE
[SRVKS-1000] Use SO repo's script to install serverless

### DIFF
--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -11,10 +11,10 @@ readonly YAML_OUTPUT_DIR="openshift/release/artifacts/"
 rm -rf "$YAML_OUTPUT_DIR"
 mkdir -p "$YAML_OUTPUT_DIR"
 
-readonly SERVING_CRD_YAML=${YAML_OUTPUT_DIR}/1-serving-crds.yaml
-readonly SERVING_CORE_YAML=${YAML_OUTPUT_DIR}/2-serving-core.yaml
-readonly SERVING_HPA_YAML=${YAML_OUTPUT_DIR}/3-serving-hpa.yaml
-readonly SERVING_POST_INSTALL_JOBS_YAML=${YAML_OUTPUT_DIR}/4-serving-post-install-jobs.yaml
+readonly SERVING_CRD_YAML=${YAML_OUTPUT_DIR}/serving-crds.yaml
+readonly SERVING_CORE_YAML=${YAML_OUTPUT_DIR}/serving-core.yaml
+readonly SERVING_HPA_YAML=${YAML_OUTPUT_DIR}/serving-hpa.yaml
+readonly SERVING_POST_INSTALL_JOBS_YAML=${YAML_OUTPUT_DIR}/serving-post-install-jobs.yaml
 
 if [[ "$VERSION" == "ci" ]]; then
   # Do not use devel as operator checks the version.

--- a/openshift/release/knative-eventing-ci.yaml
+++ b/openshift/release/knative-eventing-ci.yaml
@@ -1,1 +1,0 @@
-# This is a dummy file. "knative-eventing" directory and a manifest file is mandatory when KO_DATA_PATH was overwritten.


### PR DESCRIPTION
As per title, this patch changes to use SO repo's script.

https://github.com/openshift-knative/serving/pull/81#discussion_r1049354250 also mentioned.

/cc @skonto @ReToCode 