### PR TITLE
Add kntest binary to build-image

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -8,6 +8,7 @@ ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/
 RUN yum install -y kubectl httpd-tools
 
 RUN GOFLAGS='' go install github.com/mikefarah/yq/v3@latest
+RUN GOFLAGS='' go install knative.dev/test-infra/tools/kntest/cmd/kntest@latest
 
 # Allow runtime users to add entries to /etc/passwd
 RUN chmod g+rw /etc/passwd


### PR DESCRIPTION
According to https://coreos.slack.com/archives/CF5ANN61F/p1671632436145429?thread_ts=1671614040.063949&cid=CF5ANN61F. This add kntest to the build image to avoid `command kntest not found` errors.

/cherry-pick main
/cherry-pick release-v1.8