### PR TITLE
Ignore initcontainers and multicontainer test images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ CGO_ENABLED=0
 GOOS=linux
 CORE_IMAGES=./cmd/activator ./cmd/autoscaler ./cmd/autoscaler-hpa ./cmd/controller ./cmd/queue ./cmd/webhook ./vendor/knative.dev/pkg/apiextensions/storageversion/cmd/migrate ./cmd/domain-mapping ./cmd/domain-mapping-webhook
 TEST_IMAGES=$(shell find ./test/test_images ./test/test_images/multicontainer -mindepth 1 -maxdepth 1 -type d)
+# Exclude wrapper images like multicontainer and initcontainers as those are just ko convenience wrappers used upstream. The openshift serverless tests use other images to run.
+TEST_IMAGES_WITHOUT_WRAPPERS=$(shell find ./test/test_images ./test/test_images/multicontainer -mindepth 1 -maxdepth 1 -type d -not -name multicontainer -not -name initcontainers)
 BRANCH=
 TEST=
 IMAGE=
@@ -19,7 +21,7 @@ install:
 .PHONY: install
 
 test-install:
-	for img in $(TEST_IMAGES); do \
+	for img in $(TEST_IMAGES_WITHOUT_WRAPPERS); do \
 		go install $$img ; \
 	done
 .PHONY: test-install
@@ -59,7 +61,7 @@ test-e2e-local:
 # Generate Dockerfiles for core and test images used by ci-operator. The files need to be committed manually.
 generate-dockerfiles:
 	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/knative-images $(CORE_IMAGES)
-	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/knative-test-images $(TEST_IMAGES)
+	./openshift/ci-operator/generate-dockerfiles.sh openshift/ci-operator/knative-test-images $(TEST_IMAGES_WITHOUT_WRAPPERS)
 .PHONY: generate-dockerfiles
 
 # Generates a ci-operator configuration for a specific branch.

--- a/openshift/ci-operator/generate-ci-config.sh
+++ b/openshift/ci-operator/generate-ci-config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 branch=${1-'knative-v0.6.0'}
 openshift=${2-'4.3'}
@@ -14,6 +14,7 @@ else
 fi
 
 core_images=$(find ./openshift/ci-operator/knative-images -mindepth 1 -maxdepth 1 -type d | LC_COLLATE=posix sort)
+# Exclude wrapper images like multicontainer and initcontainers as those are just ko convenience wrappers used upstream. The openshift serverless tests use other images to run.
 exclude_images="-not -name multicontainer -not -name initcontainers"
 test_images=$(find ./openshift/ci-operator/knative-test-images -mindepth 1 -maxdepth 1 -type d $exclude_images | LC_COLLATE=posix sort)
 

--- a/openshift/ci-operator/generate-dockerfiles.sh
+++ b/openshift/ci-operator/generate-dockerfiles.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -x
 
-function generate_dockefiles() {
+function generate_dockerfiles() {
   local target_dir=$1; shift
   for img in $@; do
     local image_base=$(basename $img)
@@ -11,4 +11,4 @@ function generate_dockefiles() {
   done
 }
 
-generate_dockefiles $@
+generate_dockerfiles $@

--- a/openshift/ci-operator/update-ci.sh
+++ b/openshift/ci-operator/update-ci.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # A script that will update the mapping file in github.com/openshift/release
 
 set -e
@@ -28,9 +28,9 @@ test -n "$VERSION" || fail "'$BRANCH' is not a release branch"
 # Set up variables for important locations in the openshift/release repo.
 OPENSHIFT=$(realpath "$1"); shift
 test -d "$OPENSHIFT/.git" || fail "'$OPENSHIFT' is not a git repo"
-CONFIGDIR=$OPENSHIFT/ci-operator/config/openshift/knative-serving
+CONFIGDIR=$OPENSHIFT/ci-operator/config/openshift-knative/serving
 test -d "$CONFIGDIR" || fail "'$CONFIGDIR' is not a directory"
-PERIODIC_CONFIGDIR=$OPENSHIFT/ci-operator/jobs/openshift/knative-serving
+PERIODIC_CONFIGDIR=$OPENSHIFT/ci-operator/jobs/openshift-knative/serving
 test -d "$PERIODIC_CONFIGDIR" || fail "'$PERIODIC_CONFIGDIR' is not a directory"
 
 # Generate CI config files

--- a/openshift/release/create-release-branch.sh
+++ b/openshift/release/create-release-branch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Usage: create-release-branch.sh v0.4.1 release-0.4
 


### PR DESCRIPTION
- Ignore multicontainer and initcontainers images
- Use `#!/usr/bin/env bash` as shebang for scripts to also work on MacOS
- Fix typo in `generate_dockerfiles`
- Update path for new repository layout `openshift-knative/serving`