### PR TITLE
[RELEASE-1.7] Remove initcontainers and multicontainer test images

### DIFF
--- a/openshift/ci-operator/knative-test-images/initcontainers/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/initcontainers/Dockerfile
@@ -1,6 +1,0 @@
-# Do not edit! This file was generated via Makefile
-FROM openshift/origin-base
-USER 65532
-
-ADD initcontainers /ko-app/initcontainers
-ENTRYPOINT ["/ko-app/initcontainers"]

--- a/openshift/ci-operator/knative-test-images/multicontainer/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/multicontainer/Dockerfile
@@ -1,6 +1,0 @@
-# Do not edit! This file was generated via Makefile
-FROM openshift/origin-base
-USER 65532
-
-ADD multicontainer /ko-app/multicontainer
-ENTRYPOINT ["/ko-app/multicontainer"]


### PR DESCRIPTION
- Remove initcontainers and multicontainer test images

ℹ️ This is just to avoid potential future issues, if we need to regenerate ci-files.