### PR TITLE
[RELEASE-1.7] Self contained dockerfiles for images

### DIFF
--- a/openshift/ci-operator/Dockerfile_with_kodata.in
+++ b/openshift/ci-operator/Dockerfile_with_kodata.in
@@ -7,5 +7,6 @@ RUN make install test-install
 FROM openshift/origin-base
 USER 65532
 
+COPY ${kodata_path} /var/run/ko
 COPY --from=builder /go/bin/${bin} /ko-app/${bin}
 ENTRYPOINT ["/ko-app/${bin}"]

--- a/openshift/ci-operator/generate-dockerfiles.sh
+++ b/openshift/ci-operator/generate-dockerfiles.sh
@@ -1,13 +1,20 @@
 #!/bin/bash
 
-set -x
+set -e
 
 function generate_dockefiles() {
   local target_dir=$1; shift
+  # Remove old images and re-generate, avoid stale images hanging around.
   for img in $@; do
     local image_base=$(basename $img)
+    local kodata_path="$img/kodata"
     mkdir -p $target_dir/$image_base
-    bin=$image_base envsubst < openshift/ci-operator/Dockerfile.in > $target_dir/$image_base/Dockerfile
+    if [ -d "$kodata_path" ]
+    then
+      bin=$image_base kodata_path=$kodata_path envsubst < openshift/ci-operator/Dockerfile_with_kodata.in > $target_dir/$image_base/Dockerfile
+    else
+      bin=$image_base envsubst < openshift/ci-operator/Dockerfile.in > $target_dir/$image_base/Dockerfile
+    fi
   done
 }
 

--- a/openshift/ci-operator/knative-images/activator/Dockerfile
+++ b/openshift/ci-operator/knative-images/activator/Dockerfile
@@ -1,6 +1,12 @@
 # Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 USER 65532
 
-ADD activator /ko-app/activator
+COPY ./cmd/activator/kodata /var/run/ko
+COPY --from=builder /go/bin/activator /ko-app/activator
 ENTRYPOINT ["/ko-app/activator"]

--- a/openshift/ci-operator/knative-images/autoscaler-hpa/Dockerfile
+++ b/openshift/ci-operator/knative-images/autoscaler-hpa/Dockerfile
@@ -1,6 +1,12 @@
 # Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 USER 65532
 
-ADD autoscaler-hpa /ko-app/autoscaler-hpa
+COPY ./cmd/autoscaler-hpa/kodata /var/run/ko
+COPY --from=builder /go/bin/autoscaler-hpa /ko-app/autoscaler-hpa
 ENTRYPOINT ["/ko-app/autoscaler-hpa"]

--- a/openshift/ci-operator/knative-images/autoscaler/Dockerfile
+++ b/openshift/ci-operator/knative-images/autoscaler/Dockerfile
@@ -1,6 +1,12 @@
 # Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 USER 65532
 
-ADD autoscaler /ko-app/autoscaler
+COPY ./cmd/autoscaler/kodata /var/run/ko
+COPY --from=builder /go/bin/autoscaler /ko-app/autoscaler
 ENTRYPOINT ["/ko-app/autoscaler"]

--- a/openshift/ci-operator/knative-images/controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/controller/Dockerfile
@@ -1,6 +1,12 @@
 # Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 USER 65532
 
-ADD controller /ko-app/controller
+COPY ./cmd/controller/kodata /var/run/ko
+COPY --from=builder /go/bin/controller /ko-app/controller
 ENTRYPOINT ["/ko-app/controller"]

--- a/openshift/ci-operator/knative-images/domain-mapping-webhook/Dockerfile
+++ b/openshift/ci-operator/knative-images/domain-mapping-webhook/Dockerfile
@@ -1,6 +1,11 @@
 # Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 USER 65532
 
-ADD domain-mapping-webhook /ko-app/domain-mapping-webhook
+COPY --from=builder /go/bin/domain-mapping-webhook /ko-app/domain-mapping-webhook
 ENTRYPOINT ["/ko-app/domain-mapping-webhook"]

--- a/openshift/ci-operator/knative-images/domain-mapping/Dockerfile
+++ b/openshift/ci-operator/knative-images/domain-mapping/Dockerfile
@@ -1,6 +1,11 @@
 # Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 USER 65532
 
-ADD domain-mapping /ko-app/domain-mapping
+COPY --from=builder /go/bin/domain-mapping /ko-app/domain-mapping
 ENTRYPOINT ["/ko-app/domain-mapping"]

--- a/openshift/ci-operator/knative-images/migrate/Dockerfile
+++ b/openshift/ci-operator/knative-images/migrate/Dockerfile
@@ -1,6 +1,11 @@
 # Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 USER 65532
 
-ADD migrate /ko-app/migrate
+COPY --from=builder /go/bin/migrate /ko-app/migrate
 ENTRYPOINT ["/ko-app/migrate"]

--- a/openshift/ci-operator/knative-images/queue/Dockerfile
+++ b/openshift/ci-operator/knative-images/queue/Dockerfile
@@ -1,6 +1,12 @@
 # Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 USER 65532
 
-ADD queue /ko-app/queue
+COPY ./cmd/queue/kodata /var/run/ko
+COPY --from=builder /go/bin/queue /ko-app/queue
 ENTRYPOINT ["/ko-app/queue"]

--- a/openshift/ci-operator/knative-images/webhook/Dockerfile
+++ b/openshift/ci-operator/knative-images/webhook/Dockerfile
@@ -1,6 +1,12 @@
 # Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 USER 65532
 
-ADD webhook /ko-app/webhook
+COPY ./cmd/webhook/kodata /var/run/ko
+COPY --from=builder /go/bin/webhook /ko-app/webhook
 ENTRYPOINT ["/ko-app/webhook"]

--- a/openshift/ci-operator/knative-test-images/autoscale/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/autoscale/Dockerfile
@@ -1,6 +1,11 @@
 # Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 USER 65532
 
-ADD autoscale /ko-app/autoscale
+COPY --from=builder /go/bin/autoscale /ko-app/autoscale
 ENTRYPOINT ["/ko-app/autoscale"]

--- a/openshift/ci-operator/knative-test-images/failing/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/failing/Dockerfile
@@ -1,6 +1,11 @@
 # Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 USER 65532
 
-ADD failing /ko-app/failing
+COPY --from=builder /go/bin/failing /ko-app/failing
 ENTRYPOINT ["/ko-app/failing"]

--- a/openshift/ci-operator/knative-test-images/grpc-ping/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/grpc-ping/Dockerfile
@@ -1,6 +1,11 @@
 # Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 USER 65532
 
-ADD grpc-ping /ko-app/grpc-ping
+COPY --from=builder /go/bin/grpc-ping /ko-app/grpc-ping
 ENTRYPOINT ["/ko-app/grpc-ping"]

--- a/openshift/ci-operator/knative-test-images/hellohttp2/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/hellohttp2/Dockerfile
@@ -1,6 +1,11 @@
 # Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 USER 65532
 
-ADD hellohttp2 /ko-app/hellohttp2
+COPY --from=builder /go/bin/hellohttp2 /ko-app/hellohttp2
 ENTRYPOINT ["/ko-app/hellohttp2"]

--- a/openshift/ci-operator/knative-test-images/hellovolume/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/hellovolume/Dockerfile
@@ -1,6 +1,11 @@
 # Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 USER 65532
 
-ADD hellovolume /ko-app/hellovolume
+COPY --from=builder /go/bin/hellovolume /ko-app/hellovolume
 ENTRYPOINT ["/ko-app/hellovolume"]

--- a/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
@@ -1,6 +1,11 @@
 # Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 USER 65532
 
-ADD helloworld /ko-app/helloworld
+COPY --from=builder /go/bin/helloworld /ko-app/helloworld
 ENTRYPOINT ["/ko-app/helloworld"]

--- a/openshift/ci-operator/knative-test-images/httpproxy/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/httpproxy/Dockerfile
@@ -1,6 +1,11 @@
 # Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 USER 65532
 
-ADD httpproxy /ko-app/httpproxy
+COPY --from=builder /go/bin/httpproxy /ko-app/httpproxy
 ENTRYPOINT ["/ko-app/httpproxy"]

--- a/openshift/ci-operator/knative-test-images/initcontainers/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/initcontainers/Dockerfile
@@ -7,5 +7,5 @@ RUN make install test-install
 FROM openshift/origin-base
 USER 65532
 
-COPY --from=builder /go/bin/wsserver /ko-app/wsserver
-ENTRYPOINT ["/ko-app/wsserver"]
+COPY --from=builder /go/bin/initcontainers /ko-app/initcontainers
+ENTRYPOINT ["/ko-app/initcontainers"]

--- a/openshift/ci-operator/knative-test-images/multicontainer/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/multicontainer/Dockerfile
@@ -7,5 +7,5 @@ RUN make install test-install
 FROM openshift/origin-base
 USER 65532
 
-COPY --from=builder /go/bin/wsserver /ko-app/wsserver
-ENTRYPOINT ["/ko-app/wsserver"]
+COPY --from=builder /go/bin/multicontainer /ko-app/multicontainer
+ENTRYPOINT ["/ko-app/multicontainer"]

--- a/openshift/ci-operator/knative-test-images/pizzaplanetv1/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/pizzaplanetv1/Dockerfile
@@ -1,6 +1,11 @@
 # Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 USER 65532
 
-ADD pizzaplanetv1 /ko-app/pizzaplanetv1
+COPY --from=builder /go/bin/pizzaplanetv1 /ko-app/pizzaplanetv1
 ENTRYPOINT ["/ko-app/pizzaplanetv1"]

--- a/openshift/ci-operator/knative-test-images/pizzaplanetv2/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/pizzaplanetv2/Dockerfile
@@ -1,6 +1,11 @@
 # Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 USER 65532
 
-ADD pizzaplanetv2 /ko-app/pizzaplanetv2
+COPY --from=builder /go/bin/pizzaplanetv2 /ko-app/pizzaplanetv2
 ENTRYPOINT ["/ko-app/pizzaplanetv2"]

--- a/openshift/ci-operator/knative-test-images/readiness/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/readiness/Dockerfile
@@ -1,6 +1,11 @@
 # Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 USER 65532
 
-ADD readiness /ko-app/readiness
+COPY --from=builder /go/bin/readiness /ko-app/readiness
 ENTRYPOINT ["/ko-app/readiness"]

--- a/openshift/ci-operator/knative-test-images/runtime/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/runtime/Dockerfile
@@ -1,6 +1,11 @@
 # Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 USER 65532
 
-ADD runtime /ko-app/runtime
+COPY --from=builder /go/bin/runtime /ko-app/runtime
 ENTRYPOINT ["/ko-app/runtime"]

--- a/openshift/ci-operator/knative-test-images/servingcontainer/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/servingcontainer/Dockerfile
@@ -1,6 +1,11 @@
 # Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 USER 65532
 
-ADD servingcontainer /ko-app/servingcontainer
+COPY --from=builder /go/bin/servingcontainer /ko-app/servingcontainer
 ENTRYPOINT ["/ko-app/servingcontainer"]

--- a/openshift/ci-operator/knative-test-images/sidecarcontainer/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/sidecarcontainer/Dockerfile
@@ -1,6 +1,11 @@
 # Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 USER 65532
 
-ADD sidecarcontainer /ko-app/sidecarcontainer
+COPY --from=builder /go/bin/sidecarcontainer /ko-app/sidecarcontainer
 ENTRYPOINT ["/ko-app/sidecarcontainer"]

--- a/openshift/ci-operator/knative-test-images/singlethreaded/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/singlethreaded/Dockerfile
@@ -1,6 +1,11 @@
 # Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 USER 65532
 
-ADD singlethreaded /ko-app/singlethreaded
+COPY --from=builder /go/bin/singlethreaded /ko-app/singlethreaded
 ENTRYPOINT ["/ko-app/singlethreaded"]

--- a/openshift/ci-operator/knative-test-images/timeout/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/timeout/Dockerfile
@@ -1,6 +1,11 @@
 # Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 USER 65532
 
-ADD timeout /ko-app/timeout
+COPY --from=builder /go/bin/timeout /ko-app/timeout
 ENTRYPOINT ["/ko-app/timeout"]

--- a/openshift/ci-operator/knative-test-images/volumes/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/volumes/Dockerfile
@@ -1,6 +1,11 @@
 # Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+
+COPY . .
+RUN make install test-install
+
 FROM openshift/origin-base
 USER 65532
 
-ADD volumes /ko-app/volumes
+COPY --from=builder /go/bin/volumes /ko-app/volumes
 ENTRYPOINT ["/ko-app/volumes"]


### PR DESCRIPTION
Fixes JIRA: https://issues.redhat.com/browse/SRVKS-989

**Changes**
🧹 Use self contained dockerfiles for images (based on https://github.com/openshift/knative-eventing/pull/1785).

/hold for tests