### PR TITLE
Self contained containerfiles for serving images

### DIFF
--- a/openshift/ci-operator/Dockerfile_with_kodata.in
+++ b/openshift/ci-operator/Dockerfile_with_kodata.in
@@ -7,5 +7,6 @@ RUN make install test-install
 FROM openshift/origin-base
 USER 65532
 
+COPY ${kodata_path} /var/run/ko
 COPY --from=builder /go/bin/${bin} /ko-app/${bin}
 ENTRYPOINT ["/ko-app/${bin}"]

--- a/openshift/ci-operator/generate-dockerfiles.sh
+++ b/openshift/ci-operator/generate-dockerfiles.sh
@@ -1,13 +1,20 @@
 #!/usr/bin/env bash
 
-set -x
+set -e
 
 function generate_dockerfiles() {
   local target_dir=$1; shift
+  # Remove old images and re-generate, avoid stale images hanging around.
   for img in $@; do
     local image_base=$(basename $img)
+    local kodata_path="$img/kodata"
     mkdir -p $target_dir/$image_base
-    bin=$image_base envsubst < openshift/ci-operator/Dockerfile.in > $target_dir/$image_base/Dockerfile
+    if [ -d "$kodata_path" ]
+    then
+      bin=$image_base kodata_path=$kodata_path envsubst < openshift/ci-operator/Dockerfile_with_kodata.in > $target_dir/$image_base/Dockerfile
+    else
+      bin=$image_base envsubst < openshift/ci-operator/Dockerfile.in > $target_dir/$image_base/Dockerfile
+    fi
   done
 }
 


### PR DESCRIPTION
Fixes JIRA: https://issues.redhat.com/browse/SRVKS-989

**Changes**
🧹 Use self contained dockerfiles for images (based on https://github.com/openshift/knative-eventing/pull/1785).

Tested on
* https://github.com/openshift-knative/serving/pull/115
* https://github.com/openshift-knative/serving/pull/117


/hold for https://github.com/openshift-knative/serving/pull/115#issuecomment-1378289332