### PR TITLE
[RELEASE-1.7][BACKPORT] Don't default Revision values when BYO name is unchanged. 

### DIFF
--- a/pkg/apis/serving/v1/configuration_defaults.go
+++ b/pkg/apis/serving/v1/configuration_defaults.go
@@ -23,20 +23,49 @@ import (
 	"knative.dev/serving/pkg/apis/serving"
 )
 
+type configSpecKey struct{}
+
+// WithPreviousConfigurationSpec stores the pre-update ConfigurationSpec in the
+// context, to allow ConfigurationSpec.SetDefaults to determine whether the
+// update would create a new Revision.
+func WithPreviousConfigurationSpec(ctx context.Context, spec *ConfigurationSpec) context.Context {
+	return context.WithValue(ctx, configSpecKey{}, spec)
+}
+
+func previousConfigSpec(ctx context.Context) *ConfigurationSpec {
+	if spec, ok := ctx.Value(configSpecKey{}).(*ConfigurationSpec); ok {
+		return spec
+	}
+	return nil
+}
+
 // SetDefaults implements apis.Defaultable
 func (c *Configuration) SetDefaults(ctx context.Context) {
 	ctx = apis.WithinParent(ctx, c.ObjectMeta)
+
+	var prevSpec *ConfigurationSpec
+	if prev, ok := apis.GetBaseline(ctx).(*Configuration); ok && prev != nil {
+		prevSpec = &prev.Spec
+		ctx = WithPreviousConfigurationSpec(ctx, prevSpec)
+	}
+
 	c.Spec.SetDefaults(apis.WithinSpec(ctx))
+
 	if c.GetOwnerReferences() == nil {
-		if apis.IsInUpdate(ctx) {
-			serving.SetUserInfo(ctx, apis.GetBaseline(ctx).(*Configuration).Spec, c.Spec, c)
-		} else {
-			serving.SetUserInfo(ctx, nil, c.Spec, c)
-		}
+		serving.SetUserInfo(ctx, prevSpec, &c.Spec, c)
 	}
 }
 
 // SetDefaults implements apis.Defaultable
 func (cs *ConfigurationSpec) SetDefaults(ctx context.Context) {
+	if prev := previousConfigSpec(ctx); prev != nil {
+		newName := cs.Template.ObjectMeta.Name
+		oldName := prev.Template.ObjectMeta.Name
+		if newName != "" && newName == oldName {
+			// Skip defaulting, to avoid suggesting changes that would conflict with
+			// "BYO RevisionName".
+			return
+		}
+	}
 	cs.Template.SetDefaults(ctx)
 }

--- a/pkg/apis/serving/v1/service_defaults.go
+++ b/pkg/apis/serving/v1/service_defaults.go
@@ -26,13 +26,16 @@ import (
 // SetDefaults implements apis.Defaultable
 func (s *Service) SetDefaults(ctx context.Context) {
 	ctx = apis.WithinParent(ctx, s.ObjectMeta)
-	s.Spec.SetDefaults(apis.WithinSpec(ctx))
 
-	if apis.IsInUpdate(ctx) {
-		serving.SetUserInfo(ctx, apis.GetBaseline(ctx).(*Service).Spec, s.Spec, s)
-	} else {
-		serving.SetUserInfo(ctx, nil, s.Spec, s)
+	var prevSpec *ServiceSpec
+	if prev, ok := apis.GetBaseline(ctx).(*Service); ok && prev != nil {
+		prevSpec = &prev.Spec
+		ctx = WithPreviousConfigurationSpec(ctx, &prev.Spec.ConfigurationSpec)
 	}
+
+	s.Spec.SetDefaults(apis.WithinSpec(ctx))
+	serving.SetUserInfo(ctx, prevSpec, &s.Spec, s)
+
 }
 
 // SetDefaults implements apis.Defaultable


### PR DESCRIPTION
* Backport of https://github.com/knative/serving/pull/13565
* Required for the work in https://github.com/openshift-knative/serving/pull/68 (SRVKS-985) and for backporting https://github.com/knative/serving/pull/13398
* This should allow upgarde tests to pass as discussed in https://github.com/openshift-knative/serverless-operator/pull/1862#issuecomment-1339669021