### PR TITLE
Avoid replacing seccompProfile in CRD files

### DIFF
--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -23,9 +23,15 @@ function resolve_file() {
   # 1. Rewrite image references
   # 2. Update config map entry
   # 3. Replace serving.knative.dev/release label.
-  # 4. Remove seccompProfile.
-  sed -e "s+app.kubernetes.io/version: devel+app.kubernetes.io/version: \""$version"\"+" \
-      -e "s+seccompProfile:++" \
-      -e "s+type: RuntimeDefault++" \
-      "$file" >> "$to"
+  # 4. Remove seccompProfile, except on CRD files in 300-resources folder to avoid breaking CRDs.
+  if [[ $file == config/core//300-resources/* ]]; then
+    sed -e "s+app.kubernetes.io/version: devel+app.kubernetes.io/version: \""$version"\"+" \
+        -e "s+type: RuntimeDefault++" \
+        "$file" >> "$to"
+  else
+    sed -e "s+app.kubernetes.io/version: devel+app.kubernetes.io/version: \""$version"\"+" \
+        -e "s+seccompProfile:++" \
+        -e "s+type: RuntimeDefault++" \
+        "$file" >> "$to"
+  fi
 }


### PR DESCRIPTION
Fixes the build issues on `release-next`. Tested on https://github.com/openshift-knative/serving/pull/143.

**Changes**
- Avoid replacing `seccompProfile` in CRD files

/cc @skonto, @nak3 