### PR TITLE
Avoid replacing seccompProfile in CRD files

### DIFF
--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -24,7 +24,7 @@ function resolve_file() {
   # 2. Update config map entry
   # 3. Replace serving.knative.dev/release label.
   # 4. Remove seccompProfile, except on CRD files in 300-resources folder to avoid breaking CRDs.
-  if [[ $file == config/core//300-resources/* ]]; then
+  if [[ $file == */300-resources/* ]]; then
     sed -e "s+app.kubernetes.io/version: devel+app.kubernetes.io/version: \""$version"\"+" \
         -e "s+type: RuntimeDefault++" \
         "$file" >> "$to"


### PR DESCRIPTION
The script is called for multiple paths, unfortunately the different base paths result in different amount of trailing/leading slashes:

```
Writing resolved yaml to openshift/release/artifacts//serving-crds.yaml
file: config/core/300-imagecache.yaml
file: config/core/300-resources//certificate.yaml
...
```
vs.
```
Writing resolved yaml to openshift/release/artifacts//serving-core.yaml
file: config/core//300-imagecache.yaml
file: config/core//300-resources/certificate.yaml
...
```

Tested in https://github.com/openshift-knative/serving/pull/147

/hold for tests