### PR TITLE
[RELEASE-1.7] Add missing label to serving-certs-ctrl-ca

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -237,7 +237,7 @@ EOF
   wait_until_hostname_resolves "$(kubectl get svc -n $SERVING_INGRESS_NAMESPACE kourier -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')"
 
   # TODO: Only one cluster enables internal-tls but it should be enabled by default when the feature is stable.
-  if [[ ${ENABLE_INTERNAL_TLS} == "true" ]]; then
+  if [[ ${ENABLE_INTERNAL_TLS:-} == "true" ]]; then
     oc patch knativeserving knative-serving \
         -n "${SERVING_NAMESPACE}" \
         --type merge --patch '{"spec": {"config": {"network": {"internal-encryption": "true"}}}}'

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -229,6 +229,13 @@ spec:
       logging.enable-request-log: "true"
 EOF
 
+  # Wait for 4 pods to appear first
+  timeout 600 '[[ $(oc get pods -n $SERVING_NAMESPACE --no-headers | wc -l) -lt 4 ]]' || return 1
+  wait_until_pods_running $SERVING_NAMESPACE || return 1
+
+  wait_until_service_has_external_ip $SERVING_INGRESS_NAMESPACE kourier || fail_test "Ingress has no external IP"
+  wait_until_hostname_resolves "$(kubectl get svc -n $SERVING_INGRESS_NAMESPACE kourier -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')"
+
   # TODO: Only one cluster enables internal-tls but it should be enabled by default when the feature is stable.
   if [[ ${ENABLE_INTERNAL_TLS} == "true" ]]; then
     oc patch knativeserving knative-serving \
@@ -245,13 +252,6 @@ EOF
     oc wait --timeout=60s --for=condition=Available deployment  -n ${SERVING_NAMESPACE} activator
     echo "internal-encryption is enabled"
   fi
-
-  # Wait for 4 pods to appear first
-  timeout 600 '[[ $(oc get pods -n $SERVING_NAMESPACE --no-headers | wc -l) -lt 4 ]]' || return 1
-  wait_until_pods_running $SERVING_NAMESPACE || return 1
-
-  wait_until_service_has_external_ip $SERVING_INGRESS_NAMESPACE kourier || fail_test "Ingress has no external IP"
-  wait_until_hostname_resolves "$(kubectl get svc -n $SERVING_INGRESS_NAMESPACE kourier -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')"
 
   header "Knative Installed successfully"
 }

--- a/openshift/release/artifacts/2-serving-core.yaml
+++ b/openshift/release/artifacts/2-serving-core.yaml
@@ -4327,8 +4327,11 @@ metadata:
   # https://github.com/knative-sandbox/control-protocol/blob/main/pkg/certificates/reconciler/controller.go
   name: serving-certs-ctrl-ca
   namespace: knative-serving
-
+  labels:
+    serving-certs-ctrl: "data-plane"
+    networking.internal.knative.dev/certificate-uid: "serving-certs"
 # The data is populated when internal-encryption is enabled.
+
 ---
 apiVersion: v1
 kind: Secret

--- a/openshift/release/knative-serving-ci.yaml
+++ b/openshift/release/knative-serving-ci.yaml
@@ -4334,6 +4334,9 @@ metadata:
   # https://github.com/knative-sandbox/control-protocol/blob/main/pkg/certificates/reconciler/controller.go
   name: serving-certs-ctrl-ca
   namespace: knative-serving
+  labels:
+    serving-certs-ctrl: "data-plane"
+    networking.internal.knative.dev/certificate-uid: "serving-certs"
 # The data is populated when internal-encryption is enabled.
 ---
 apiVersion: v1


### PR DESCRIPTION
This patch includes two fixes:
- Add the lable in `serving-certs-ctrl-ca` which follows up f612214ac3df61a69ed542db2e41ba7e808a3992
- cherry-pick https://github.com/openshift/knative-serving/pull/1266

Without this, 1.7 with TLS CI keeps failing https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serving-release-v1.7-411-e2e-aws-ocp-tls-411

Note, the presubmit CI for TLS does not exist in 1.7 branch (will add it after this PR) https://github.com/openshift-knative/serving/pull/163 verified the fix.

Also, this PR is not necessary to cherry-pick for 1.8 as it was included.

/cc @skonto @ReToCode 