### PR TITLE
[RELEASE-1.6] Fix CI script for TLS

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -230,7 +230,7 @@ spec:
 EOF
 
   # TODO: Only one cluster enables internal-tls but it should be enabled by default when the feature is stable.
-  if [[ ${ENABLE_INTERNAL_TLS} == "true" ]]; then
+  if [[ ${ENABLE_INTERNAL_TLS:-} == "true" ]]; then
     oc patch knativeserving knative-serving \
         -n "${SERVING_NAMESPACE}" \
         --type merge --patch '{"spec": {"config": {"network": {"internal-encryption": "true"}}}}'

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -229,6 +229,13 @@ spec:
       logging.enable-request-log: "true"
 EOF
 
+  # Wait for 4 pods to appear first
+  timeout 600 '[[ $(oc get pods -n $SERVING_NAMESPACE --no-headers | wc -l) -lt 4 ]]' || return 1
+  wait_until_pods_running $SERVING_NAMESPACE || return 1
+
+  wait_until_service_has_external_ip $SERVING_INGRESS_NAMESPACE kourier || fail_test "Ingress has no external IP"
+  wait_until_hostname_resolves "$(kubectl get svc -n $SERVING_INGRESS_NAMESPACE kourier -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')"
+
   # TODO: Only one cluster enables internal-tls but it should be enabled by default when the feature is stable.
   if [[ ${ENABLE_INTERNAL_TLS:-} == "true" ]]; then
     oc patch knativeserving knative-serving \
@@ -245,13 +252,6 @@ EOF
     oc wait --timeout=60s --for=condition=Available deployment  -n ${SERVING_NAMESPACE} activator
     echo "internal-encryption is enabled"
   fi
-
-  # Wait for 4 pods to appear first
-  timeout 600 '[[ $(oc get pods -n $SERVING_NAMESPACE --no-headers | wc -l) -lt 4 ]]' || return 1
-  wait_until_pods_running $SERVING_NAMESPACE || return 1
-
-  wait_until_service_has_external_ip $SERVING_INGRESS_NAMESPACE kourier || fail_test "Ingress has no external IP"
-  wait_until_hostname_resolves "$(kubectl get svc -n $SERVING_INGRESS_NAMESPACE kourier -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')"
 
   header "Knative Installed successfully"
 }


### PR DESCRIPTION
__This PR does not contain code change but just fix a script for CI.__

This patch cherry-pick https://github.com/openshift/knative-serving/pull/1266.

Without this, 1.6 with TLS CI is flaky https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serving-release-v1.6-411-e2e-aws-ocp-tls-411

Note, the presubmit CI for TLS does not exist in 1.6 branch (will add it after this PR) but #164 verified the fix.

Also, this PR is not necessary to cherry-pick for other branches as it was included.
