### PR TITLE
Bump CI template to 4.10,4.11 from 4.8,4.9

### DIFF
--- a/openshift/ci-operator/update-ci.sh
+++ b/openshift/ci-operator/update-ci.sh
@@ -40,8 +40,8 @@ PERIODIC_CONFIG=$PERIODIC_CONFIGDIR/openshift-knative-serving-release-$VERSION-p
 CURDIR=$(dirname $0)
 
 # $1=branch $2=openshift $3=promotion_disabled $4=generate_continuous $5=internal_tls_enabled(optional)
-$CURDIR/generate-ci-config.sh knative-$VERSION 4.8 true false > ${CONFIG}__48.yaml
-$CURDIR/generate-ci-config.sh knative-$VERSION 4.9 true false > ${CONFIG}__49.yaml
+$CURDIR/generate-ci-config.sh knative-$VERSION 4.10 true false > ${CONFIG}__410.yaml
+$CURDIR/generate-ci-config.sh knative-$VERSION 4.11 true false > ${CONFIG}__411.yaml
 $CURDIR/generate-ci-config.sh knative-$VERSION 4.12 true false > ${CONFIG}__412.yaml
 $CURDIR/generate-ci-config.sh knative-$VERSION 4.12 false true true > ${CONFIG}__412.yaml
 


### PR DESCRIPTION
As per title, this patch bumps CI template to 4.10,4.11 from 4.8,4.9.
