### PR TITLE
[RELEASE-1.9] Avoid replacing seccompProfile in CRD files 

### DIFF
--- a/openshift/release/artifacts/serving-core.yaml
+++ b/openshift/release/artifacts/serving-core.yaml
@@ -21,7 +21,7 @@ metadata:
   # (which should be identical, but isn't guaranteed to be installed alongside serving).
   name: knative-serving-aggregated-addressable-resolver
   labels:
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     app.kubernetes.io/name: knative-serving
 aggregationRule:
   clusterRoleSelectors:
@@ -33,7 +33,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-addressable-resolver
   labels:
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     app.kubernetes.io/name: knative-serving
     # Labeled to facilitate aggregated cluster roles that act on Addressables.
     duck.knative.dev/addressable: "true"
@@ -72,7 +72,7 @@ metadata:
   name: knative-serving-namespaced-admin
   labels:
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev"]
@@ -88,7 +88,7 @@ metadata:
   name: knative-serving-namespaced-edit
   labels:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev"]
@@ -104,7 +104,7 @@ metadata:
   name: knative-serving-namespaced-view
   labels:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: ["serving.knative.dev", "networking.internal.knative.dev", "autoscaling.internal.knative.dev", "caching.internal.knative.dev"]
@@ -131,7 +131,7 @@ metadata:
   name: knative-serving-core
   labels:
     serving.knative.dev/controller: "true"
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     app.kubernetes.io/name: knative-serving
 rules:
   - apiGroups: [""]
@@ -210,7 +210,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: knative-serving-podspecable-binding
   labels:
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     app.kubernetes.io/name: knative-serving
     # Labeled to facilitate aggregated cluster roles that act on PodSpecables.
     duck.knative.dev/podspecable: "true"
@@ -249,7 +249,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -257,7 +257,7 @@ metadata:
   name: knative-serving-admin
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
 aggregationRule:
   clusterRoleSelectors:
   - matchLabels:
@@ -270,7 +270,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -287,7 +287,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
 subjects:
   - kind: ServiceAccount
     name: controller
@@ -317,7 +317,7 @@ metadata:
   name: images.caching.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     knative.dev/crd-install: "true"
 spec:
   group: caching.internal.knative.dev
@@ -438,7 +438,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: networking
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -586,7 +586,7 @@ metadata:
   name: configurations.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/podspecable: "true"
 spec:
@@ -1044,7 +1044,7 @@ spec:
                                     description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                     type: integer
                                     format: int64
-                                  
+                                  seccompProfile:
                                     description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
                                     type: object
                                     required:
@@ -1423,7 +1423,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: networking
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -1486,7 +1486,7 @@ metadata:
   name: domainmappings.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -1754,7 +1754,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: networking
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -2013,7 +2013,7 @@ metadata:
   name: metrics.autoscaling.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -2134,7 +2134,7 @@ metadata:
   name: podautoscalers.autoscaling.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -2293,7 +2293,7 @@ metadata:
   name: revisions.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -2730,7 +2730,7 @@ spec:
                             description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                             type: integer
                             format: int64
-                          
+                          seccompProfile:
                             description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
                             type: object
                             required:
@@ -3137,7 +3137,7 @@ metadata:
   name: routes.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
 spec:
@@ -3310,7 +3310,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: networking
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -3475,7 +3475,7 @@ metadata:
   name: services.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
     duck.knative.dev/podspecable: "true"
@@ -3937,7 +3937,7 @@ spec:
                                     description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                     type: integer
                                     format: int64
-                                  
+                                  seccompProfile:
                                     description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
                                     type: object
                                     required:
@@ -4414,7 +4414,7 @@ metadata:
   labels:
     app.kubernetes.io/component: queue-proxy
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
 spec:
   # This is the Go import path for the binary that is containerized
   # and substituted here.
@@ -4442,7 +4442,7 @@ metadata:
   labels:
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
   annotations:
     knative.dev/example-checksum: "47c2487f"
 data:
@@ -4652,7 +4652,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
   annotations:
     knative.dev/example-checksum: "e7973912"
 data:
@@ -4806,7 +4806,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
   annotations:
     knative.dev/example-checksum: "ac007ed2"
 data:
@@ -4920,7 +4920,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
   annotations:
     knative.dev/example-checksum: "26c09de5"
 data:
@@ -4984,7 +4984,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
   annotations:
     knative.dev/example-checksum: "d3565159"
 data:
@@ -5188,7 +5188,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
   annotations:
     knative.dev/example-checksum: "aa3813a8"
 data:
@@ -5287,7 +5287,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: controller
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
   annotations:
     knative.dev/example-checksum: "f4b71f57"
 data:
@@ -5346,7 +5346,7 @@ metadata:
   name: config-logging
   namespace: knative-serving
   labels:
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     app.kubernetes.io/component: logging
     app.kubernetes.io/name: knative-serving
   annotations:
@@ -5427,7 +5427,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: networking
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
   annotations:
     knative.dev/example-checksum: "73d96d1b"
 data:
@@ -5612,7 +5612,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: observability
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
   annotations:
     knative.dev/example-checksum: "fed4756e"
 data:
@@ -5720,7 +5720,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: tracing
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
   annotations:
     knative.dev/example-checksum: "26614636"
 data:
@@ -5776,7 +5776,7 @@ metadata:
   labels:
     app.kubernetes.io/component: activator
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
 spec:
   minReplicas: 1
   maxReplicas: 20
@@ -5804,7 +5804,7 @@ metadata:
   labels:
     app.kubernetes.io/component: activator
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
 spec:
   minAvailable: 1
   selector:
@@ -5832,7 +5832,7 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/component: activator
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     app.kubernetes.io/name: knative-serving
 spec:
   selector:
@@ -5848,7 +5848,7 @@ spec:
         role: activator
         app.kubernetes.io/component: activator
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "v1.2.0"
+        app.kubernetes.io/version: "v1.9.0"
     spec:
       serviceAccountName: controller
       containers:
@@ -5947,7 +5947,7 @@ metadata:
   labels:
     app: activator
     app.kubernetes.io/component: activator
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     app.kubernetes.io/name: knative-serving
 spec:
   selector:
@@ -5993,7 +5993,7 @@ metadata:
   labels:
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
 spec:
   replicas: 1
   selector:
@@ -6011,7 +6011,7 @@ spec:
         app: autoscaler
         app.kubernetes.io/component: autoscaler
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "v1.2.0"
+        app.kubernetes.io/version: "v1.9.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -6100,7 +6100,7 @@ metadata:
     app: autoscaler
     app.kubernetes.io/component: autoscaler
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
   name: autoscaler
   namespace: knative-serving
 spec:
@@ -6140,7 +6140,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
 spec:
   selector:
     matchLabels:
@@ -6153,7 +6153,7 @@ spec:
         app: controller
         app.kubernetes.io/component: controller
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "v1.2.0"
+        app.kubernetes.io/version: "v1.9.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -6223,7 +6223,7 @@ metadata:
     app: controller
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
   name: controller
   namespace: knative-serving
 spec:
@@ -6260,7 +6260,7 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
 spec:
   selector:
     matchLabels:
@@ -6273,7 +6273,7 @@ spec:
         app: domain-mapping
         app.kubernetes.io/component: domain-mapping
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "v1.2.0"
+        app.kubernetes.io/version: "v1.9.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -6353,7 +6353,7 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
 spec:
   selector:
     matchLabels:
@@ -6368,7 +6368,7 @@ spec:
         role: domainmapping-webhook
         app.kubernetes.io/component: domain-mapping
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "v1.2.0"
+        app.kubernetes.io/version: "v1.9.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -6465,7 +6465,7 @@ metadata:
     role: domainmapping-webhook
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
   name: domainmapping-webhook
   namespace: knative-serving
 spec:
@@ -6506,7 +6506,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
 spec:
   minReplicas: 1
   maxReplicas: 5
@@ -6532,7 +6532,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
 spec:
   minAvailable: 1
   selector:
@@ -6560,7 +6560,7 @@ metadata:
   namespace: knative-serving
   labels:
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     app.kubernetes.io/name: knative-serving
 spec:
   selector:
@@ -6575,7 +6575,7 @@ spec:
         app: webhook
         role: webhook
         app.kubernetes.io/component: webhook
-        app.kubernetes.io/version: "v1.2.0"
+        app.kubernetes.io/version: "v1.9.0"
         app.kubernetes.io/name: knative-serving
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
@@ -6674,7 +6674,7 @@ metadata:
   labels:
     role: webhook
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     app.kubernetes.io/name: knative-serving
   name: webhook
   namespace: knative-serving
@@ -6715,7 +6715,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -6756,7 +6756,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -6810,7 +6810,7 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -6856,7 +6856,7 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
 # The data is populated at install time.
 ---
 # Copyright 2020 The Knative Authors
@@ -6880,7 +6880,7 @@ metadata:
   labels:
     app.kubernetes.io/component: domain-mapping
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -6926,7 +6926,7 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
 webhooks:
 - admissionReviewVersions: ["v1", "v1beta1"]
   clientConfig:
@@ -6982,5 +6982,5 @@ metadata:
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
 # The data is populated at install time.

--- a/openshift/release/artifacts/serving-crds.yaml
+++ b/openshift/release/artifacts/serving-crds.yaml
@@ -19,7 +19,7 @@ metadata:
   name: images.caching.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     knative.dev/crd-install: "true"
 spec:
   group: caching.internal.knative.dev
@@ -140,7 +140,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: networking
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -288,7 +288,7 @@ metadata:
   name: configurations.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/podspecable: "true"
 spec:
@@ -746,7 +746,7 @@ spec:
                                     description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                     type: integer
                                     format: int64
-                                  
+                                  seccompProfile:
                                     description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
                                     type: object
                                     required:
@@ -1125,7 +1125,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: networking
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -1188,7 +1188,7 @@ metadata:
   name: domainmappings.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -1456,7 +1456,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: networking
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -1715,7 +1715,7 @@ metadata:
   name: metrics.autoscaling.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -1836,7 +1836,7 @@ metadata:
   name: podautoscalers.autoscaling.internal.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     knative.dev/crd-install: "true"
 spec:
   group: autoscaling.internal.knative.dev
@@ -1995,7 +1995,7 @@ metadata:
   name: revisions.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     knative.dev/crd-install: "true"
 spec:
   group: serving.knative.dev
@@ -2432,7 +2432,7 @@ spec:
                             description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                             type: integer
                             format: int64
-                          
+                          seccompProfile:
                             description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
                             type: object
                             required:
@@ -2839,7 +2839,7 @@ metadata:
   name: routes.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
 spec:
@@ -3012,7 +3012,7 @@ metadata:
   labels:
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: networking
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     knative.dev/crd-install: "true"
 spec:
   group: networking.internal.knative.dev
@@ -3177,7 +3177,7 @@ metadata:
   name: services.serving.knative.dev
   labels:
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
     knative.dev/crd-install: "true"
     duck.knative.dev/addressable: "true"
     duck.knative.dev/podspecable: "true"
@@ -3639,7 +3639,7 @@ spec:
                                     description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                     type: integer
                                     format: int64
-                                  
+                                  seccompProfile:
                                     description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
                                     type: object
                                     required:

--- a/openshift/release/artifacts/serving-hpa.yaml
+++ b/openshift/release/artifacts/serving-hpa.yaml
@@ -22,7 +22,7 @@ metadata:
     autoscaling.knative.dev/autoscaler-provider: hpa
     app.kubernetes.io/component: autoscaler-hpa
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
 spec:
   selector:
     matchLabels:
@@ -35,7 +35,7 @@ spec:
         app: autoscaler-hpa
         app.kubernetes.io/component: autoscaler-hpa
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "v1.2.0"
+        app.kubernetes.io/version: "v1.9.0"
     spec:
       # To avoid node becoming SPOF, spread our replicas to different nodes.
       affinity:
@@ -102,7 +102,7 @@ metadata:
     autoscaling.knative.dev/autoscaler-provider: hpa
     app.kubernetes.io/component: autoscaler-hpa
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
   name: autoscaler-hpa
   namespace: knative-serving
 spec:

--- a/openshift/release/artifacts/serving-post-install-jobs.yaml
+++ b/openshift/release/artifacts/serving-post-install-jobs.yaml
@@ -22,7 +22,7 @@ metadata:
     app: storage-version-migration-serving
     app.kubernetes.io/name: knative-serving
     app.kubernetes.io/component: storage-version-migration-job
-    app.kubernetes.io/version: "v1.2.0"
+    app.kubernetes.io/version: "v1.9.0"
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 10
@@ -34,7 +34,7 @@ spec:
         app: storage-version-migration-serving
         app.kubernetes.io/name: knative-serving
         app.kubernetes.io/component: storage-version-migration-job
-        app.kubernetes.io/version: "v1.2.0"
+        app.kubernetes.io/version: "v1.9.0"
     spec:
       serviceAccountName: controller
       restartPolicy: OnFailure

--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -24,7 +24,7 @@ function resolve_file() {
   # 2. Update config map entry
   # 3. Replace serving.knative.dev/release label.
   # 4. Remove seccompProfile, except on CRD files in 300-resources folder to avoid breaking CRDs.
-  if [[ $file == config/core//300-resources/* ]]; then
+  if [[ $file == */300-resources/* ]]; then
     sed -e "s+app.kubernetes.io/version: devel+app.kubernetes.io/version: \""$version"\"+" \
         -e "s+type: RuntimeDefault++" \
         "$file" >> "$to"

--- a/openshift/release/resolve.sh
+++ b/openshift/release/resolve.sh
@@ -23,9 +23,15 @@ function resolve_file() {
   # 1. Rewrite image references
   # 2. Update config map entry
   # 3. Replace serving.knative.dev/release label.
-  # 4. Remove seccompProfile.
-  sed -e "s+app.kubernetes.io/version: devel+app.kubernetes.io/version: \""$version"\"+" \
-      -e "s+seccompProfile:++" \
-      -e "s+type: RuntimeDefault++" \
-      "$file" >> "$to"
+  # 4. Remove seccompProfile, except on CRD files in 300-resources folder to avoid breaking CRDs.
+  if [[ $file == config/core//300-resources/* ]]; then
+    sed -e "s+app.kubernetes.io/version: devel+app.kubernetes.io/version: \""$version"\"+" \
+        -e "s+type: RuntimeDefault++" \
+        "$file" >> "$to"
+  else
+    sed -e "s+app.kubernetes.io/version: devel+app.kubernetes.io/version: \""$version"\"+" \
+        -e "s+seccompProfile:++" \
+        -e "s+type: RuntimeDefault++" \
+        "$file" >> "$to"
+  fi
 }


### PR DESCRIPTION
This patch changes to:
- cherry-picks https://github.com/openshift-knative/serving/pull/144 and https://github.com/openshift-knative/serving/pull/148
- Re-generated manifest by `./openshift/release/generate-release.sh v1.9.0`.

/cc @skonto @ReToCode 