### PR TITLE
[RELEASE-1.7][SRVKS-985] Add revision security defaults

### DIFF
--- a/config/core/300-resources/configuration.yaml
+++ b/config/core/300-resources/configuration.yaml
@@ -478,6 +478,18 @@ spec:
                                     description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                     type: integer
                                     format: int64
+                                  seccompProfile:
+                                    description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
+                                    type: object
+                                    required:
+                                      - type
+                                    properties:
+                                      localhostProfile:
+                                        description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                        type: string
+                                      type:
+                                        description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
+                                        type: string
                               terminationMessagePath:
                                 description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                 type: string

--- a/config/core/300-resources/revision.yaml
+++ b/config/core/300-resources/revision.yaml
@@ -457,6 +457,18 @@ spec:
                             description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                             type: integer
                             format: int64
+                          seccompProfile:
+                            description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
+                            type: object
+                            required:
+                              - type
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                type: string
+                              type:
+                                description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
+                                type: string
                       terminationMessagePath:
                         description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                         type: string

--- a/config/core/300-resources/service.yaml
+++ b/config/core/300-resources/service.yaml
@@ -482,6 +482,18 @@ spec:
                                     description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                     type: integer
                                     format: int64
+                                  seccompProfile:
+                                    description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
+                                    type: object
+                                    required:
+                                      - type
+                                    properties:
+                                      localhostProfile:
+                                        description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                        type: string
+                                      type:
+                                        description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
+                                        type: string
                               terminationMessagePath:
                                 description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                 type: string

--- a/config/core/configmaps/features.yaml
+++ b/config/core/configmaps/features.yaml
@@ -22,7 +22,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: devel
   annotations:
-    knative.dev/example-checksum: "c938086c"
+    knative.dev/example-checksum: "07e3a0bb"
 data:
   _example: |-
     ################################
@@ -39,6 +39,13 @@ data:
     # These sample configuration options may be copied out of
     # this example block and unindented to be in the data block
     # to actually change the configuration.
+
+    # Default SecurityContext settings to secure-by-default values
+    # if unset.
+    #
+    # This value will default to "enabled" in a future release,
+    # probably Knative 1.10
+    secure-pod-defaults: "disabled"
 
     # Indicates whether multi container support is enabled
     #

--- a/hack/schemapatch-config.yaml
+++ b/hack/schemapatch-config.yaml
@@ -286,6 +286,7 @@ k8s.io/api/core/v1.SecurityContext:
     - RunAsNonRoot
     - AllowPrivilegeEscalation
     - RunAsUser
+    - SeccompProfile
 k8s.io/api/core/v1.Capabilities:
   fieldMask:
     - Add

--- a/openshift/release/artifacts/2-serving-core.yaml
+++ b/openshift/release/artifacts/2-serving-core.yaml
@@ -1020,6 +1020,18 @@ spec:
                                     description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                     type: integer
                                     format: int64
+                                  seccompProfile:
+                                    description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
+                                    type: object
+                                    required:
+                                      - type
+                                    properties:
+                                      localhostProfile:
+                                        description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                        type: string
+                                      type:
+                                        description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
+                                        type: string
                               terminationMessagePath:
                                 description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                 type: string
@@ -2700,6 +2712,18 @@ spec:
                             description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                             type: integer
                             format: int64
+                          seccompProfile:
+                            description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
+                            type: object
+                            required:
+                              - type
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                type: string
+                              type:
+                                description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
+                                type: string
                       terminationMessagePath:
                         description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                         type: string
@@ -3898,6 +3922,18 @@ spec:
                                     description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                     type: integer
                                     format: int64
+                                  seccompProfile:
+                                    description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
+                                    type: object
+                                    required:
+                                      - type
+                                    properties:
+                                      localhostProfile:
+                                        description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                        type: string
+                                      type:
+                                        description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
+                                        type: string
                               terminationMessagePath:
                                 description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                 type: string
@@ -4929,7 +4965,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: "1.7.0"
   annotations:
-    knative.dev/example-checksum: "4d5feafc"
+    knative.dev/example-checksum: "07e3a0bb"
 data:
   _example: |-
     ################################
@@ -4946,6 +4982,13 @@ data:
     # These sample configuration options may be copied out of
     # this example block and unindented to be in the data block
     # to actually change the configuration.
+
+    # Default SecurityContext settings to secure-by-default values
+    # if unset.
+    #
+    # This value will default to "enabled" in a future release,
+    # probably Knative 1.10
+    secure-pod-defaults: "disabled"
 
     # Indicates whether multi container support is enabled
     #
@@ -5016,6 +5059,7 @@ data:
     # - RunAsNonRoot
     # - SupplementalGroups
     # - RunAsUser
+    # - SeccompProfile
     #
     # This feature flag should be used with caution as the PodSecurityContext
     # properties may have a side-effect on non-user sidecar containers that come

--- a/openshift/release/download_release_artifacts.sh
+++ b/openshift/release/download_release_artifacts.sh
@@ -57,3 +57,6 @@ git apply "${manifest_path}/003-serving-pdb.patch"
 
 # Add psp patch.
 git apply "${manifest_path}/005-psp.patch"
+
+# Add secure-pod-defaults config option.
+git apply "${manifest_path}/006-secure-pod-defaults.patch"

--- a/openshift/release/knative-serving-ci.yaml
+++ b/openshift/release/knative-serving-ci.yaml
@@ -1037,6 +1037,18 @@ spec:
                                     description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                     type: integer
                                     format: int64
+                                  seccompProfile:
+                                    description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
+                                    type: object
+                                    required:
+                                      - type
+                                    properties:
+                                      localhostProfile:
+                                        description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                        type: string
+                                      type:
+                                        description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
+                                        type: string
                               terminationMessagePath:
                                 description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                 type: string
@@ -2711,6 +2723,18 @@ spec:
                             description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                             type: integer
                             format: int64
+                          seccompProfile:
+                            description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
+                            type: object
+                            required:
+                              - type
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                type: string
+                              type:
+                                description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
+                                type: string
                       terminationMessagePath:
                         description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                         type: string
@@ -3906,6 +3930,18 @@ spec:
                                     description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                     type: integer
                                     format: int64
+                                  seccompProfile:
+                                    description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
+                                    type: object
+                                    required:
+                                      - type
+                                    properties:
+                                      localhostProfile:
+                                        description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                        type: string
+                                      type:
+                                        description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
+                                        type: string
                               terminationMessagePath:
                                 description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                 type: string
@@ -4929,7 +4965,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: "v1.2.0"
   annotations:
-    knative.dev/example-checksum: "4d5feafc"
+    knative.dev/example-checksum: "07e3a0bb"
 data:
   _example: |-
     ################################
@@ -4946,6 +4982,13 @@ data:
     # These sample configuration options may be copied out of
     # this example block and unindented to be in the data block
     # to actually change the configuration.
+
+    # Default SecurityContext settings to secure-by-default values
+    # if unset.
+    #
+    # This value will default to "enabled" in a future release,
+    # probably Knative 1.10
+    secure-pod-defaults: "disabled"
 
     # Indicates whether multi container support is enabled
     #
@@ -5016,6 +5059,7 @@ data:
     # - RunAsNonRoot
     # - SupplementalGroups
     # - RunAsUser
+    # - SeccompProfile
     #
     # This feature flag should be used with caution as the PodSecurityContext
     # properties may have a side-effect on non-user sidecar containers that come

--- a/openshift/release/knative-serving-knative-v1.7.0.yaml
+++ b/openshift/release/knative-serving-knative-v1.7.0.yaml
@@ -1037,6 +1037,18 @@ spec:
                                     description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                     type: integer
                                     format: int64
+                                  seccompProfile:
+                                    description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
+                                    type: object
+                                    required:
+                                      - type
+                                    properties:
+                                      localhostProfile:
+                                        description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                        type: string
+                                      type:
+                                        description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
+                                        type: string
                               terminationMessagePath:
                                 description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                 type: string
@@ -2711,6 +2723,18 @@ spec:
                             description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                             type: integer
                             format: int64
+                          seccompProfile:
+                            description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
+                            type: object
+                            required:
+                              - type
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                type: string
+                              type:
+                                description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
+                                type: string
                       terminationMessagePath:
                         description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                         type: string
@@ -3906,6 +3930,18 @@ spec:
                                     description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
                                     type: integer
                                     format: int64
+                                  seccompProfile:
+                                    description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
+                                    type: object
+                                    required:
+                                      - type
+                                    properties:
+                                      localhostProfile:
+                                        description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
+                                        type: string
+                                      type:
+                                        description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
+                                        type: string
                               terminationMessagePath:
                                 description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                 type: string
@@ -4926,7 +4962,7 @@ metadata:
     app.kubernetes.io/component: controller
     app.kubernetes.io/version: "v1.2.0"
   annotations:
-    knative.dev/example-checksum: "4d5feafc"
+    knative.dev/example-checksum: "07e3a0bb"
 data:
   _example: |-
     ################################
@@ -4943,6 +4979,13 @@ data:
     # These sample configuration options may be copied out of
     # this example block and unindented to be in the data block
     # to actually change the configuration.
+
+    # Default SecurityContext settings to secure-by-default values
+    # if unset.
+    #
+    # This value will default to "enabled" in a future release,
+    # probably Knative 1.10
+    secure-pod-defaults: "disabled"
 
     # Indicates whether multi container support is enabled
     #
@@ -5013,6 +5056,7 @@ data:
     # - RunAsNonRoot
     # - SupplementalGroups
     # - RunAsUser
+    # - SeccompProfile
     #
     # This feature flag should be used with caution as the PodSecurityContext
     # properties may have a side-effect on non-user sidecar containers that come

--- a/openshift/release/manifest-patches/006-secure-pod-defaults.patch
+++ b/openshift/release/manifest-patches/006-secure-pod-defaults.patch
@@ -1,0 +1,96 @@
+diff --git a/openshift/release/artifacts/2-serving-core.yaml b/openshift/release/artifacts/2-serving-core.yaml
+index f104c332a..03a30abc5 100644
+--- a/openshift/release/artifacts/2-serving-core.yaml
++++ b/openshift/release/artifacts/2-serving-core.yaml
+@@ -4926,7 +4926,7 @@ metadata:
+     app.kubernetes.io/component: controller
+     app.kubernetes.io/version: "1.7.0"
+   annotations:
+-    knative.dev/example-checksum: "4d5feafc"
++    knative.dev/example-checksum: "07e3a0bb"
+ data:
+   _example: |-
+     ################################
+@@ -4944,6 +4944,13 @@ data:
+     # this example block and unindented to be in the data block
+     # to actually change the configuration.
+
++    # Default SecurityContext settings to secure-by-default values
++    # if unset.
++    #
++    # This value will default to "enabled" in a future release,
++    # probably Knative 1.10
++    secure-pod-defaults: "disabled"
++
+     # Indicates whether multi container support is enabled
+     #
+     # WARNING: Cannot safely be disabled once enabled.
+@@ -5013,6 +5020,7 @@ data:
+     # - RunAsNonRoot
+     # - SupplementalGroups
+     # - RunAsUser
++    # - SeccompProfile
+     #
+     # This feature flag should be used with caution as the PodSecurityContext
+     # properties may have a side-effect on non-user sidecar containers that come
+diff --git a/openshift/release/artifacts/2-serving-core.yaml b/openshift/release/artifacts/2-serving-core.yaml
+index 03a30abc5..27a4d598e 100644
+--- a/openshift/release/artifacts/2-serving-core.yaml
++++ b/openshift/release/artifacts/2-serving-core.yaml
+@@ -1020,6 +1020,18 @@ spec:
+                                     description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+                                     type: integer
+                                     format: int64
++                                  seccompProfile:
++                                    description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
++                                    type: object
++                                    required:
++                                      - type
++                                    properties:
++                                      localhostProfile:
++                                        description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
++                                        type: string
++                                      type:
++                                        description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
++                                        type: string
+                               terminationMessagePath:
+                                 description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                                 type: string
+@@ -2700,6 +2712,18 @@ spec:
+                             description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+                             type: integer
+                             format: int64
++                          seccompProfile:
++                            description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
++                            type: object
++                            required:
++                              - type
++                            properties:
++                              localhostProfile:
++                                description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
++                                type: string
++                              type:
++                                description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
++                                type: string
+                       terminationMessagePath:
+                         description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                         type: string
+@@ -3898,6 +3922,18 @@ spec:
+                                     description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is windows.
+                                     type: integer
+                                     format: int64
++                                  seccompProfile:
++                                    description: The seccomp options to use by this container. If seccomp options are provided at both the pod & container level, the container options override the pod options. Note that this field cannot be set when spec.os.name is windows.
++                                    type: object
++                                    required:
++                                      - type
++                                    properties:
++                                      localhostProfile:
++                                        description: localhostProfile indicates a profile defined in a file on the node should be used. The profile must be preconfigured on the node to work. Must be a descending path, relative to the kubelet's configured seccomp profile location. Must only be set if type is "Localhost".
++                                        type: string
++                                      type:
++                                        description: "type indicates which kind of seccomp profile will be applied. Valid options are: \n Localhost - a profile defined in a file on the node should be used. RuntimeDefault - the container runtime default profile should be used. Unconfined - no profile should be applied."
++                                        type: string
+                               terminationMessagePath:
+                                 description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                                 type: string

--- a/pkg/apis/config/features.go
+++ b/pkg/apis/config/features.go
@@ -70,6 +70,7 @@ func defaultFeaturesConfig() *Features {
 		PodSpecInitContainers:            Disabled,
 		PodSpecDNSPolicy:                 Disabled,
 		PodSpecDNSConfig:                 Disabled,
+		SecurePodDefaults:                Disabled,
 		TagHeaderBasedRouting:            Disabled,
 		AutoDetectHTTP2:                  Disabled,
 	}
@@ -99,6 +100,7 @@ func NewFeaturesConfigFromMap(data map[string]string) (*Features, error) {
 		asFlag("kubernetes.podspec-persistent-volume-write", &nc.PodSpecPersistentVolumeWrite),
 		asFlag("kubernetes.podspec-dnspolicy", &nc.PodSpecDNSPolicy),
 		asFlag("kubernetes.podspec-dnsconfig", &nc.PodSpecDNSConfig),
+		asFlag("secure-pod-defaults", &nc.SecurePodDefaults),
 		asFlag("tag-header-based-routing", &nc.TagHeaderBasedRouting),
 		asFlag("queueproxy.mount-podinfo", &nc.QueueProxyMountPodInfo),
 		asFlag("autodetect-http2", &nc.AutoDetectHTTP2)); err != nil {
@@ -134,6 +136,7 @@ type Features struct {
 	QueueProxyMountPodInfo           Flag
 	PodSpecDNSPolicy                 Flag
 	PodSpecDNSConfig                 Flag
+	SecurePodDefaults                Flag
 	TagHeaderBasedRouting            Flag
 	AutoDetectHTTP2                  Flag
 }

--- a/pkg/apis/config/features_test.go
+++ b/pkg/apis/config/features_test.go
@@ -72,6 +72,7 @@ func TestFeaturesConfiguration(t *testing.T) {
 			PodSpecSchedulerName:             Enabled,
 			PodSpecDNSPolicy:                 Enabled,
 			PodSpecDNSConfig:                 Enabled,
+			SecurePodDefaults:                Enabled,
 			TagHeaderBasedRouting:            Enabled,
 		}),
 		data: map[string]string{
@@ -88,6 +89,7 @@ func TestFeaturesConfiguration(t *testing.T) {
 			"kubernetes.podspec-schedulername":             "Enabled",
 			"kubernetes.podspec-dnspolicy":                 "Enabled",
 			"kubernetes.podspec-dnsconfig":                 "Enabled",
+			"secure-pod-defaults":                          "Enabled",
 			"tag-header-based-routing":                     "Enabled",
 		},
 	}, {

--- a/pkg/apis/serving/v1/revision_defaults.go
+++ b/pkg/apis/serving/v1/revision_defaults.go
@@ -209,7 +209,7 @@ func (rs *RevisionSpec) defaultSecurityContext(ctx context.Context, psc *corev1.
 		updatedSC.AllowPrivilegeEscalation = ptr.Bool(false)
 	}
 
-	if _, ok := os.LookupEnv("OCP_SECCOMP_PROFILE_WITHOUT_SCC"); ok && !skipSeccompProfile(ctx) { // Only apply the profile in 4.11+
+	if _, ok := os.LookupEnv("KNATIVE_SET_SECCOMP_PROFILE_BY_DEFAULT_ON_THIS_OCP_VERSION"); ok && !skipSeccompProfile(ctx) { // Only apply the profile in 4.11+
 		if psc.SeccompProfile == nil || psc.SeccompProfile.Type == "" {
 			if updatedSC.SeccompProfile == nil {
 				updatedSC.SeccompProfile = &corev1.SeccompProfile{}

--- a/pkg/apis/serving/v1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1/revision_defaults_test.go
@@ -50,7 +50,7 @@ var (
 
 func TestRevisionDefaulting(t *testing.T) {
 	logger := logtesting.TestLogger(t)
-	t.Setenv("OCP_SECCOMP_PROFILE_WITHOUT_SCC", "true")
+	t.Setenv("KNATIVE_SET_SECCOMP_PROFILE_BY_DEFAULT_ON_THIS_OCP_VERSION", "true")
 	tests := []struct {
 		name string
 		in   *Revision

--- a/pkg/apis/serving/v1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1/revision_defaults_test.go
@@ -50,6 +50,7 @@ var (
 
 func TestRevisionDefaulting(t *testing.T) {
 	logger := logtesting.TestLogger(t)
+	t.Setenv("OCP_SECCOMP_PROFILE_WITHOUT_SCC", "true")
 	tests := []struct {
 		name string
 		in   *Revision
@@ -832,6 +833,200 @@ func TestRevisionDefaulting(t *testing.T) {
 					}, {
 						Name: "init-container-3",
 					}},
+				},
+			},
+		},
+	}, {
+		name: "Default security context with feature enabled",
+		wc: func(ctx context.Context) context.Context {
+			s := config.NewStore(logger)
+			s.OnConfigChanged(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: autoscalerconfig.ConfigName}})
+			s.OnConfigChanged(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: config.DefaultsConfigName}})
+			s.OnConfigChanged(
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: config.FeaturesConfigName},
+					Data:       map[string]string{"secure-pod-defaults": "Enabled"},
+				},
+			)
+
+			return s.ToContext(ctx)
+		},
+		in: &Revision{
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "user-container",
+						Ports: []corev1.ContainerPort{{
+							ContainerPort: 80,
+						}},
+					}, {
+						Name:            "sidecar",
+						SecurityContext: &corev1.SecurityContext{},
+					}, {
+						Name: "special-sidecar",
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.Bool(true),
+							Capabilities: &corev1.Capabilities{
+								Add:  []corev1.Capability{"NET_ADMIN"},
+								Drop: []corev1.Capability{},
+							},
+						},
+					}},
+					InitContainers: []corev1.Container{{
+						Name: "special-init",
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.Bool(true),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type:             corev1.SeccompProfileTypeLocalhost,
+								LocalhostProfile: ptr.String("special"),
+							},
+							Capabilities: &corev1.Capabilities{
+								Add: []corev1.Capability{"NET_ADMIN"},
+							},
+						},
+					}},
+				},
+			},
+		},
+		want: &Revision{
+			Spec: RevisionSpec{
+				ContainerConcurrency: ptr.Int64(config.DefaultContainerConcurrency),
+				TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "user-container",
+						Ports: []corev1.ContainerPort{{
+							ContainerPort: 80,
+						}},
+						ReadinessProbe: defaultProbe,
+						Resources:      defaultResources,
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+							RunAsNonRoot: ptr.Bool(true),
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+								Add:  []corev1.Capability{"NET_BIND_SERVICE"},
+							},
+						},
+					}, {
+						Name:      "sidecar",
+						Resources: defaultResources,
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+							RunAsNonRoot: ptr.Bool(true),
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+						},
+					}, {
+						Name:      "special-sidecar",
+						Resources: defaultResources,
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.Bool(true),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type: corev1.SeccompProfileTypeRuntimeDefault,
+							},
+							RunAsNonRoot: ptr.Bool(true),
+							Capabilities: &corev1.Capabilities{
+								Add:  []corev1.Capability{"NET_ADMIN"},
+								Drop: []corev1.Capability{},
+							},
+						},
+					}},
+					InitContainers: []corev1.Container{{
+						Name: "special-init",
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.Bool(true),
+							SeccompProfile: &corev1.SeccompProfile{
+								Type:             corev1.SeccompProfileTypeLocalhost,
+								LocalhostProfile: ptr.String("special"),
+							},
+							RunAsNonRoot: ptr.Bool(true),
+							Capabilities: &corev1.Capabilities{
+								Add: []corev1.Capability{"NET_ADMIN"},
+							},
+						},
+					}},
+				},
+			},
+		},
+	}, {
+		name: "uses pod defaults in security context",
+		wc: func(ctx context.Context) context.Context {
+			s := config.NewStore(logger)
+			s.OnConfigChanged(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: autoscalerconfig.ConfigName}})
+			s.OnConfigChanged(&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: config.DefaultsConfigName}})
+			s.OnConfigChanged(
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{Name: config.FeaturesConfigName},
+					Data:       map[string]string{"secure-pod-defaults": "Enabled"},
+				},
+			)
+
+			return s.ToContext(ctx)
+		},
+		in: &Revision{
+			Spec: RevisionSpec{
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "user-container",
+						Ports: []corev1.ContainerPort{{
+							ContainerPort: 8080,
+						}},
+					}},
+					InitContainers: []corev1.Container{{
+						Name:            "init",
+						SecurityContext: &corev1.SecurityContext{},
+					}},
+					SecurityContext: &corev1.PodSecurityContext{
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeUnconfined,
+						},
+					},
+				},
+			},
+		},
+		want: &Revision{
+			Spec: RevisionSpec{
+				ContainerConcurrency: ptr.Int64(config.DefaultContainerConcurrency),
+				TimeoutSeconds:       ptr.Int64(config.DefaultRevisionTimeoutSeconds),
+				PodSpec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name: "user-container",
+						Ports: []corev1.ContainerPort{{
+							ContainerPort: 8080,
+						}},
+						ReadinessProbe: defaultProbe,
+						Resources:      defaultResources,
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							RunAsNonRoot:             ptr.Bool(true),
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+						},
+					}},
+					InitContainers: []corev1.Container{{
+						Name: "init",
+						SecurityContext: &corev1.SecurityContext{
+							AllowPrivilegeEscalation: ptr.Bool(false),
+							RunAsNonRoot:             ptr.Bool(true),
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
+						},
+					}},
+					SecurityContext: &corev1.PodSecurityContext{
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeUnconfined,
+						},
+					},
 				},
 			},
 		},

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -395,7 +395,7 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 		}
 	}
 
-	if _, ok := os.LookupEnv("OCP_SECCOMP_PROFILE_WITHOUT_SCC"); ok && !shouldSkipSeccompProfile { // Only apply the profile in 4.11+
+	if _, ok := os.LookupEnv("KNATIVE_SET_SECCOMP_PROFILE_BY_DEFAULT_ON_THIS_OCP_VERSION"); ok && !shouldSkipSeccompProfile { // Only apply the profile in 4.11+
 		if psc.SeccompProfile == nil || psc.SeccompProfile.Type == "" {
 			updatedSC = &corev1.SecurityContext{
 				AllowPrivilegeEscalation: ptr.Bool(false),

--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -19,6 +19,7 @@ package resources
 import (
 	"fmt"
 	"math"
+	"os"
 	"path"
 	"strconv"
 
@@ -259,14 +260,15 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 		}
 	}
 
+	psc := rev.Spec.PodSpec.SecurityContext
+
 	c := &corev1.Container{
-		Name:            QueueContainerName,
-		Image:           cfg.Deployment.QueueSidecarImage,
-		Resources:       createQueueResources(cfg.Deployment, rev.GetAnnotations(), container),
-		Ports:           ports,
-		StartupProbe:    execProbe,
-		ReadinessProbe:  httpProbe,
-		SecurityContext: queueSecurityContext,
+		Name:           QueueContainerName,
+		Image:          cfg.Deployment.QueueSidecarImage,
+		Resources:      createQueueResources(cfg.Deployment, rev.GetAnnotations(), container),
+		Ports:          ports,
+		StartupProbe:   execProbe,
+		ReadinessProbe: httpProbe,
 		Env: []corev1.EnvVar{{
 			Name:  "SERVING_NAMESPACE",
 			Value: rev.Namespace,
@@ -379,6 +381,40 @@ func makeQueueContainer(rev *v1.Revision, cfg *config.Config) (*corev1.Container
 		}},
 	}
 
+	if psc == nil {
+		psc = &corev1.PodSecurityContext{}
+	}
+	updatedSC := queueSecurityContext
+
+	shouldSkipSeccompProfile := false
+	if v, ok := rev.GetAnnotations()[v1.SkipSeccompProfileAnnotation]; ok {
+		if b, err := strconv.ParseBool(v); err == nil {
+			if b {
+				shouldSkipSeccompProfile = true
+			}
+		}
+	}
+
+	if _, ok := os.LookupEnv("OCP_SECCOMP_PROFILE_WITHOUT_SCC"); ok && !shouldSkipSeccompProfile { // Only apply the profile in 4.11+
+		if psc.SeccompProfile == nil || psc.SeccompProfile.Type == "" {
+			updatedSC = &corev1.SecurityContext{
+				AllowPrivilegeEscalation: ptr.Bool(false),
+				ReadOnlyRootFilesystem:   ptr.Bool(true),
+				RunAsNonRoot:             ptr.Bool(true),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+				},
+			}
+			if updatedSC.SeccompProfile == nil {
+				updatedSC.SeccompProfile = &corev1.SeccompProfile{}
+			}
+			if updatedSC.SeccompProfile.Type == "" {
+				updatedSC.SeccompProfile.Type = corev1.SeccompProfileTypeRuntimeDefault
+			}
+		}
+	}
+
+	c.SecurityContext = updatedSC
 	return c, nil
 }
 

--- a/pkg/testing/v1/service.go
+++ b/pkg/testing/v1/service.go
@@ -182,6 +182,15 @@ func WithRevisionTimeoutSeconds(revisionTimeoutSeconds int64) ServiceOption {
 	}
 }
 
+// WithRevisionAnnotation adds the given annotation to the revision.
+func WithRevisionAnnotation(k, v string) ServiceOption {
+	return func(service *v1.Service) {
+		service.Spec.Template.Annotations = kmeta.UnionMaps(service.Spec.Template.Annotations, map[string]string{
+			k: v,
+		})
+	}
+}
+
 // WithRevisionResponseStartTimeoutSeconds sets revision first byte timeout
 func WithRevisionResponseStartTimeoutSeconds(revisionResponseStartTimeoutSeconds int64) ServiceOption {
 	return func(service *v1.Service) {

--- a/pkg/webhook/validate_unstructured.go
+++ b/pkg/webhook/validate_unstructured.go
@@ -110,5 +110,5 @@ func validateRevisionTemplate(ctx context.Context, uns *unstructured.Unstructure
 		}
 	}
 
-	return validatePodSpec(ctx, templ.Spec, namespace, mode)
+	return validatePodSpec(v1.MaybeSkipSeccompProfile(ctx, templ.Annotations), templ.Spec, namespace, mode)
 }

--- a/test/conformance/runtime/user_test.go
+++ b/test/conformance/runtime/user_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/test"
 
 	. "knative.dev/serving/pkg/testing/v1"
@@ -84,7 +85,7 @@ func TestShouldRunAsUserContainerDefault(t *testing.T) {
 
 	t.Parallel()
 	clients := test.Setup(t)
-	_, ri, err := fetchRuntimeInfo(t, clients)
+	_, ri, err := fetchRuntimeInfo(t, clients, WithRevisionAnnotation(servingv1.SkipSeccompProfileAnnotation, "true"))
 
 	if err != nil {
 		t.Fatal("Error fetching runtime info:", err)

--- a/test/conformance/runtime/user_test.go
+++ b/test/conformance/runtime/user_test.go
@@ -51,7 +51,7 @@ func TestMustRunAsUser(t *testing.T) {
 
 	// We need to modify the working dir because the specified user cannot access the
 	// default user's working dir.
-	_, ri, err := fetchRuntimeInfo(t, clients, WithSecurityContext(securityContext), WithWorkingDir("/"))
+	_, ri, err := fetchRuntimeInfo(t, clients, WithSecurityContext(securityContext), WithWorkingDir("/"), WithRevisionAnnotation(servingv1.SkipSeccompProfileAnnotation, "true"))
 	if err != nil {
 		t.Fatal("Error fetching runtime info:", err)
 	}

--- a/test/e2e/pvc/pvc_test.go
+++ b/test/e2e/pvc/pvc_test.go
@@ -27,6 +27,7 @@ import (
 	"knative.dev/pkg/ptr"
 	pkgTest "knative.dev/pkg/test"
 	"knative.dev/pkg/test/spoof"
+	servingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	. "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
 	v1test "knative.dev/serving/test/v1"
@@ -65,7 +66,9 @@ func TestPersistentVolumeClaims(t *testing.T) {
 		FSGroup: ptr.Int64(unprivilegedUserID),
 	})
 
-	resources, err := v1test.CreateServiceReady(t, clients, &names, withVolume, withPodSecurityContext)
+	withRevisionAnnotation := WithRevisionAnnotation(servingv1.SkipSeccompProfileAnnotation, "true")
+
+	resources, err := v1test.CreateServiceReady(t, clients, &names, withVolume, withPodSecurityContext, withRevisionAnnotation)
 	if err != nil {
 		t.Fatalf("Failed to create initial Service: %v: %v", names.Service, err)
 	}

--- a/test/e2e/securedefaults/secure_pod_defaults_test.go
+++ b/test/e2e/securedefaults/secure_pod_defaults_test.go
@@ -1,0 +1,117 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2023 The Knative Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package securedefaults
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/injection/sharedmain"
+	"knative.dev/pkg/ptr"
+	. "knative.dev/serving/pkg/testing/v1"
+	"knative.dev/serving/test"
+	v1test "knative.dev/serving/test/v1"
+)
+
+func TestSecureDefaults(t *testing.T) {
+	if !test.ServingFlags.EnableAlphaFeatures {
+		t.Skip("Alpha features not enabled")
+	}
+	t.Parallel()
+	clients := test.Setup(t)
+
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   test.HelloWorld,
+	}
+
+	test.EnsureTearDown(t, clients, &names)
+
+	t.Log("Creating a new Service")
+
+	resources, err := v1test.CreateServiceReady(t, clients, &names)
+	if err != nil {
+		t.Fatalf("Failed to create service with default SecurityContext: %v: %v", names.Service, err)
+	}
+
+	revisionSC := resources.Revision.Spec.Containers[0].SecurityContext
+	if revisionSC == nil {
+		t.Fatal("Container SecurityContext was nil, should have been defaulted.")
+	}
+	if len(revisionSC.Capabilities.Drop) != 1 || revisionSC.Capabilities.Drop[0] != "ALL" {
+		t.Errorf("Expected to Drop 'ALL' capability: %v", revisionSC.Capabilities)
+	}
+	if revisionSC.AllowPrivilegeEscalation == nil || *revisionSC.AllowPrivilegeEscalation {
+		t.Errorf("Expected allowPrivilegeEscalation: false, got %v", revisionSC.AllowPrivilegeEscalation)
+	}
+
+	if err := sharedmain.CheckMinimumKubeVersion(clients.KubeClient.Discovery(), "1.24.0"); err == nil {
+		if revisionSC.SeccompProfile == nil || revisionSC.SeccompProfile.Type != v1.SeccompProfileTypeRuntimeDefault {
+			t.Errorf("Expected seccompProfile to be RuntimeDefault, got: %v", revisionSC.SeccompProfile)
+		}
+	}
+}
+
+func TestUnsafePermitted(t *testing.T) {
+	if !test.ServingFlags.EnableAlphaFeatures {
+		t.Skip("Alpha features not enabled")
+	}
+	t.Parallel()
+	clients := test.Setup(t)
+
+	names := test.ResourceNames{
+		Service: test.ObjectNameForTest(t),
+		Image:   test.HelloWorld,
+	}
+
+	test.EnsureTearDown(t, clients, &names)
+
+	t.Log("Creating a new Service")
+
+	withDefaultUnsafeContext := WithSecurityContext(&v1.SecurityContext{
+		Capabilities: &v1.Capabilities{
+			Drop: []v1.Capability{},
+		},
+		RunAsNonRoot:             ptr.Bool(false),
+		AllowPrivilegeEscalation: ptr.Bool(true),
+		SeccompProfile: &v1.SeccompProfile{
+			Type: v1.SeccompProfileTypeUnconfined,
+		},
+	})
+
+	resources, err := v1test.CreateServiceReady(t, clients, &names, withDefaultUnsafeContext)
+	if err != nil {
+		t.Fatalf("Failed to create service with explicit k8s default SecurityContext: %v: %v", names.Service, err)
+	}
+
+	revisionSC := resources.Revision.Spec.Containers[0].SecurityContext
+	if revisionSC == nil {
+		t.Fatal("Container SecurityContext was nil, requested non-nil.")
+	}
+	if len(revisionSC.Capabilities.Drop) != 0 {
+		t.Errorf("Expected to Drop no capabilities (empty list): %v", revisionSC.Capabilities)
+	}
+	if revisionSC.AllowPrivilegeEscalation == nil || !*revisionSC.AllowPrivilegeEscalation {
+		t.Errorf("Expected allowPrivilegeEscalation: true, got %v", revisionSC.AllowPrivilegeEscalation)
+	}
+	if revisionSC.SeccompProfile == nil || revisionSC.SeccompProfile.Type != v1.SeccompProfileTypeUnconfined {
+		t.Errorf("Expected seccompProfile to be Unconfined, got: %v", revisionSC.SeccompProfile)
+	}
+}

--- a/test/e2e/securedefaults/secure_pod_defaults_test.go
+++ b/test/e2e/securedefaults/secure_pod_defaults_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
-	"knative.dev/pkg/injection/sharedmain"
+	"knative.dev/pkg/injection"
 	"knative.dev/pkg/ptr"
 	. "knative.dev/serving/pkg/testing/v1"
 	"knative.dev/serving/test"
@@ -62,7 +62,7 @@ func TestSecureDefaults(t *testing.T) {
 		t.Errorf("Expected allowPrivilegeEscalation: false, got %v", revisionSC.AllowPrivilegeEscalation)
 	}
 
-	if err := sharedmain.CheckMinimumKubeVersion(clients.KubeClient.Discovery(), "1.24.0"); err == nil {
+	if err := injection.CheckMinimumVersion(clients.KubeClient.Discovery(), "1.24.0"); err == nil {
 		if revisionSC.SeccompProfile == nil || revisionSC.SeccompProfile.Type != v1.SeccompProfileTypeRuntimeDefault {
 			t.Errorf("Expected seccompProfile to be RuntimeDefault, got: %v", revisionSC.SeccompProfile)
 		}

--- a/vendor/knative.dev/pkg/injection/sharedmain/main.go
+++ b/vendor/knative.dev/pkg/injection/sharedmain/main.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
+	"k8s.io/client-go/discovery"
 	cminformer "knative.dev/pkg/configmap/informer"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection"
@@ -53,6 +54,8 @@ import (
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/version"
 	"knative.dev/pkg/webhook"
+
+	"github.com/blang/semver/v4"
 )
 
 func init() {
@@ -226,6 +229,10 @@ func MainWithConfig(ctx context.Context, component string, cfg *rest.Config, cto
 	profilingServer := profiling.NewServer(profilingHandler)
 
 	CheckK8sClientMinimumVersionOrDie(ctx, logger)
+	// HACK: should go away when we move away from < 4.11 releases
+	if err := CheckMinimumKubeVersion(kubeclient.Get(ctx).Discovery(), "1.24.0"); err == nil {
+		os.Setenv("OCP_SECCOMP_PROFILE_WITHOUT_SCC", "true")
+	}
 	cmw := SetupConfigMapWatchOrDie(ctx, logger)
 
 	// Set up leader election config
@@ -435,4 +442,42 @@ func ControllersAndWebhooksFromCtors(ctx context.Context,
 	}
 
 	return controllers, webhooks
+}
+
+// CheckMinimumKubeVersion checks if current K8s version we are on is higher than the one passed.
+// If an error is returned then the version is not higher than the minimum
+func CheckMinimumKubeVersion(versioner discovery.ServerVersionInterface, version string) error {
+	v, err := versioner.ServerVersion()
+	if err != nil {
+		return err
+	}
+	currentVersion, err := semver.Make(normalizeVersion(v.GitVersion))
+	if err != nil {
+		return err
+	}
+
+	minimumVersion, err := semver.Make(normalizeVersion(version))
+	if err != nil {
+		return err
+	}
+
+	// If no specific pre-release requirement is set, we default to "-0" to always allow
+	// pre-release versions of the same Major.Minor.Patch version.
+	if len(minimumVersion.Pre) == 0 {
+		minimumVersion.Pre = []semver.PRVersion{{VersionNum: 0, IsNum: true}}
+	}
+
+	if currentVersion.LT(minimumVersion) {
+		return fmt.Errorf("kubernetes version %q is not compatible, need at least %q",
+			currentVersion, minimumVersion)
+	}
+	return nil
+}
+
+func normalizeVersion(v string) string {
+	if strings.HasPrefix(v, "v") {
+		// No need to account for unicode widths.
+		return v[1:]
+	}
+	return v
 }

--- a/vendor/knative.dev/pkg/injection/sharedmain/main.go
+++ b/vendor/knative.dev/pkg/injection/sharedmain/main.go
@@ -40,7 +40,6 @@ import (
 	"k8s.io/client-go/rest"
 
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
-	"k8s.io/client-go/discovery"
 	cminformer "knative.dev/pkg/configmap/informer"
 	"knative.dev/pkg/controller"
 	"knative.dev/pkg/injection"
@@ -54,8 +53,6 @@ import (
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/version"
 	"knative.dev/pkg/webhook"
-
-	"github.com/blang/semver/v4"
 )
 
 func init() {
@@ -230,8 +227,8 @@ func MainWithConfig(ctx context.Context, component string, cfg *rest.Config, cto
 
 	CheckK8sClientMinimumVersionOrDie(ctx, logger)
 	// HACK: should go away when we move away from < 4.11 releases
-	if err := CheckMinimumKubeVersion(kubeclient.Get(ctx).Discovery(), "1.24.0"); err == nil {
-		os.Setenv("OCP_SECCOMP_PROFILE_WITHOUT_SCC", "true")
+	if err := injection.CheckMinimumVersion(kubeclient.Get(ctx).Discovery(), "1.24.0"); err == nil {
+		os.Setenv("KNATIVE_SET_SECCOMP_PROFILE_BY_DEFAULT_ON_THIS_OCP_VERSION", "true")
 	}
 	cmw := SetupConfigMapWatchOrDie(ctx, logger)
 
@@ -442,42 +439,4 @@ func ControllersAndWebhooksFromCtors(ctx context.Context,
 	}
 
 	return controllers, webhooks
-}
-
-// CheckMinimumKubeVersion checks if current K8s version we are on is higher than the one passed.
-// If an error is returned then the version is not higher than the minimum
-func CheckMinimumKubeVersion(versioner discovery.ServerVersionInterface, version string) error {
-	v, err := versioner.ServerVersion()
-	if err != nil {
-		return err
-	}
-	currentVersion, err := semver.Make(normalizeVersion(v.GitVersion))
-	if err != nil {
-		return err
-	}
-
-	minimumVersion, err := semver.Make(normalizeVersion(version))
-	if err != nil {
-		return err
-	}
-
-	// If no specific pre-release requirement is set, we default to "-0" to always allow
-	// pre-release versions of the same Major.Minor.Patch version.
-	if len(minimumVersion.Pre) == 0 {
-		minimumVersion.Pre = []semver.PRVersion{{VersionNum: 0, IsNum: true}}
-	}
-
-	if currentVersion.LT(minimumVersion) {
-		return fmt.Errorf("kubernetes version %q is not compatible, need at least %q",
-			currentVersion, minimumVersion)
-	}
-	return nil
-}
-
-func normalizeVersion(v string) string {
-	if strings.HasPrefix(v, "v") {
-		// No need to account for unicode widths.
-		return v[1:]
-	}
-	return v
 }


### PR DESCRIPTION
- Adapted/backported from https://github.com/knative/serving/pull/13398
We will enable the feature by default at the S-O side on OCP 4.11+ as we did with deprecated apis.
The feature flag is: `secure-pod-defaults`. 
- [Tested on 4.13](https://gist.github.com/skonto/9eacd2b42b367958f1877f4c72f12a7f) for audit warnings. To test follow the process here (you need the latest oc version to avoid failures):
```
oc adm must-gather -- /usr/bin/gather_audit_logs
cd must-gather.local....
gunzip -r *
find ./ -type f -exec grep -l "violation" {} \; | xargs cat | grep violation
```
- Introduces `"serving.knative.openshift.io/skipSeccompProfile"` as a revision annotation that allows to skip setting seccomProfile for a service so it can run with the default image user. Since we support versions < 4.11 SeccompProfile is only set by default in versions > 4.10.