### PR TITLE
[release-v1.7] Fix sc for psp compliance for autoscaler-hpa

### DIFF
--- a/openshift/patches/009-hpa-capabilities.patch
+++ b/openshift/patches/009-hpa-capabilities.patch
@@ -1,0 +1,13 @@
+diff --git a/openshift/release/artifacts/3-serving-hpa.yaml b/openshift/release/artifacts/3-serving-hpa.yaml
+index d98de0e50..2d713bec7 100644
+--- a/openshift/release/artifacts/3-serving-hpa.yaml
++++ b/openshift/release/artifacts/3-serving-hpa.yaml
+@@ -77,7 +77,7 @@ spec:
+             runAsNonRoot: true
+             capabilities:
+               drop:
+-                - all
++                - ALL
+           ports:
+             - name: metrics
+               containerPort: 9090

--- a/openshift/release/artifacts/3-serving-hpa.yaml
+++ b/openshift/release/artifacts/3-serving-hpa.yaml
@@ -77,7 +77,7 @@ spec:
             runAsNonRoot: true
             capabilities:
               drop:
-                - all
+                - ALL
           ports:
             - name: metrics
               containerPort: 9090

--- a/openshift/release/knative-serving-ci.yaml
+++ b/openshift/release/knative-serving-ci.yaml
@@ -6989,7 +6989,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
 
         ports:
         - name: metrics

--- a/openshift/release/knative-serving-knative-v1.7.0.yaml
+++ b/openshift/release/knative-serving-knative-v1.7.0.yaml
@@ -6986,7 +6986,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - all
+            - ALL
 
         ports:
         - name: metrics


### PR DESCRIPTION
This patch seds `s/all/ALL/g` for autoscaler-hpa deployments, which missed in https://github.com/openshift-knative/serving/pull/14.

/cc @skonto @ReToCode 