### PR TITLE
[wip] [RELEASE1.7] [SRVKS-1044] Enable add capabilities

### DIFF
--- a/pkg/apis/serving/fieldmask.go
+++ b/pkg/apis/serving/fieldmask.go
@@ -675,7 +675,7 @@ func CapabilitiesMask(ctx context.Context, in *corev1.Capabilities) *corev1.Capa
 	// Allowed fields
 	out.Drop = in.Drop
 
-	if config.FromContextOrDefaults(ctx).Features.ContainerSpecAddCapabilities != config.Disabled {
+	if config.FromContextOrDefaults(ctx).Features.ContainerSpecAddCapabilities != config.Disabled || config.FromContextOrDefaults(ctx).Features.SecurePodDefaults != config.Disabled {
 		out.Add = in.Add
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a blocker for 1.28.

We need to enable add capabilities with sec-pod-defaults so we avoid the validation error when
low ports are used since we add NET_BIND_SERVICE in revision defaults. This does not mean that we can add arbitrary
capabilities with the new PSS on OCP, it is the same with any other deployment that does not have the privileges (same approach that we have for podsecuritycontext).
Here is an [example](https://gist.github.com/skonto/5521a43731116bf9a83c6c41bc7cd3af) of an attempt to set a not allowed capability.

Tests for low ports:
https://gist.github.com/skonto/1ed312080da1fc1cd2495a1fc213c724
https://gist.github.com/skonto/89ed314a5cd32236890086cb07f1fb86

It seems we cant offer the exact same UX as described in the steps to reproduce this in SRVKS-1044. 

**Which issue(s) this PR fixes**:
partially:
JIRA: https://issues.redhat.com/browse/SRVKS-1044

**Does this PR needs for other branches**:

<!--
If no, just write "NONE".
If yes, add cherry-pick label:

/cherry-pick release-vX.Y
-->
/cherry-pick release-v1.8

**Does this PR (patch) needs to update/drop in the future?**:

<!--
If no, just write "NONE".
If yes, please open the JIRA and link here:
-->

NONE
