### PR TITLE
[RELEASE1.7] [SRVKS-1044]  Skip setting NET_BIND_SERVICE  for the privileged ports case

### DIFF
--- a/pkg/apis/serving/v1/revision_defaults.go
+++ b/pkg/apis/serving/v1/revision_defaults.go
@@ -209,17 +209,6 @@ func (rs *RevisionSpec) defaultSecurityContext(psc *corev1.PodSecurityContext, c
 	if updatedSC.Capabilities == nil {
 		updatedSC.Capabilities = &corev1.Capabilities{}
 		updatedSC.Capabilities.Drop = []corev1.Capability{"ALL"}
-		// Default in NET_BIND_SERVICE to allow binding to low-numbered ports.
-		needsLowPort := false
-		for _, p := range container.Ports {
-			if p.ContainerPort > 0 && p.ContainerPort < 1024 {
-				needsLowPort = true
-				break
-			}
-		}
-		if updatedSC.Capabilities.Add == nil && needsLowPort {
-			updatedSC.Capabilities.Add = []corev1.Capability{"NET_BIND_SERVICE"}
-		}
 	}
 	if psc.RunAsNonRoot == nil && updatedSC.RunAsNonRoot == nil {
 		updatedSC.RunAsNonRoot = ptr.Bool(true)

--- a/pkg/apis/serving/v1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1/revision_defaults_test.go
@@ -904,7 +904,6 @@ func TestRevisionDefaulting(t *testing.T) {
 							RunAsNonRoot:             ptr.Bool(true),
 							Capabilities: &corev1.Capabilities{
 								Drop: []corev1.Capability{"ALL"},
-								Add:  []corev1.Capability{"NET_BIND_SERVICE"},
 							},
 						},
 					}, {


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a blocker for 1.28.

The current ksvc UX is that the user sets 
```
 oc adm policy add-scc-to-user anyuid -z default -n <namespace>
```
and then can use privileged ports (this is true for a normal K8s deployment that uses privileged ports on 4.10 and 4.11+, the latter has PSS enabled). Privileged ports are low ports: >0 & < 1024. This results in a pod running with scc anyuid and as a root.

On previous version of Serverless we provided the same UX with ksvc services. With 1.28 and targeting 4.13 PSS compliance though we aim for a more secure deployment for a ksvc (using restricted-v2 scc by default) and trying to avoid any audit warnings. The latter means we set a couple of fields by default including runAsNonRoot: true, drop ALL capabilities, add NET_BIND_SERVICE capability with privileged ports. 

This PR removes the NET_BIND_SERVICE capability added by default when lower ports are used. The reason we do this  is that this requires add_capabilities feature flag to be enabled and although restricted-v2 allows  NET_BIND_SERVICE (the only capability allowed under that scc), user needs to do additional steps to make privileged ports bind which is to add [at his Dockerfile](https://cloud.redhat.com/blog/linux-capabilities-in-openshift): 

```
RUN setcap 'cap_net_bind_service=+ep' <path-to-binary>
```
Example:

```
kind: Service
metadata:
  name: helloworld
spec:
  template:
    metadata:
      annotations:
        autoscaling.knative.dev/min-scale: "1"
    spec:
      imagePullPolicy: Always
      containers:
        - image: docker.io/skonto/knative-helloworld:debug
          ports:
          - containerPort: 80
          securityContext:
            capabilities:
              add:
                - "NET_BIND_SERVICE"
   

FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
COPY . .
RUN go install ./cmd/helloworld
FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
USER 65532
COPY --from=builder /go/bin/helloworld /ko-app/helloworld
USER root
RUN setcap 'cap_net_bind_service=+ep'  /ko-app/helloworld
USER 65532
ENTRYPOINT ["/ko-app/helloworld"]
```

This is a no go, although it is an option if user wants to run his workload without root and just wants to bind to a low port. 
Goal here is to **keep current UX**.
However, we cant avoid setting runAsNonRoot: true, drop ALL capabilities in order to achieve PSS compliance by default, so in order to bind to low ports the user needs to set:

```
apiVersion: serving.knative.dev/v1
kind: Service
metadata:
  name: func-git
  labels:
    app: git
spec:
  template:
    metadata:
      annotations:
        autoscaling.knative.dev/max-scale: "1"
        autoscaling.knative.dev/min-scale: "1"
    spec:
      containers:
      - image: <image with root>
        ports:
        - containerPort: 80
        securityContext:
          capabilities: {}
          runAsNonRoot: false
```
`capabilities: {}` overrides default values to allow setguid so we can run with root while `runAsNonRoot: false`
removes the default restriction of using only non root users.

All scenarios tested are listed [here](https://gist.github.com/skonto/bee52d22bfff5f7e6572dfac468739f7).

**Which issue(s) this PR fixes**:
partially:
JIRA: https://issues.redhat.com/browse/SRVKS-1044

**Does this PR needs for other branches**:

<!--
If no, just write "NONE".
If yes, add cherry-pick label:

/cherry-pick release-vX.Y
-->
/cherry-pick release-v1.8

**Does this PR (patch) needs to update/drop in the future?**:

<!--
If no, just write "NONE".
If yes, please open the JIRA and link here:
-->

NONE
