### PR TITLE
[RELEASE-1.9] Security pod defaults 1.9

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -167,8 +167,6 @@ function prepare_knative_serving_tests_nightly {
   # Apply persistent volume claim needed, needed for the related e2e test.
   oc apply -f ./test/config/pvc/pvc.yaml
 
-  oc adm policy add-scc-to-user privileged -z default -n serving-tests
-  oc adm policy add-scc-to-user privileged -z default -n serving-tests-alt
   # Adding scc for anyuid to test TestShouldRunAsUserContainerDefault.
   oc adm policy add-scc-to-user anyuid -z default -n serving-tests
 
@@ -212,6 +210,9 @@ function run_e2e_tests(){
   # Give the controller time to sync with the rest of the system components.
   sleep 30
   subdomain=$(oc get ingresses.config.openshift.io cluster  -o jsonpath="{.spec.domain}")
+
+  # Enable secure pod defaults for all tests.
+  oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"secure-pod-defaults": "enabled"}}}}' || fail_test
 
   if [ -n "$test_name" ]; then
     oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"kubernetes.podspec-volumes-emptydir": "enabled"}}}}' || fail_test
@@ -384,6 +385,31 @@ function run_e2e_tests(){
     --https \
     --skip-cleanup-on-fail \
     --resolvabledomain || failed=1
+
+
+  # Verify that the right sc is set by default and seccompProfile is injected on OCP >= 4.11.
+  go_test_e2e -timeout=10m ./test/e2e/securedefaults -run "^(TestSecureDefaults)$" \
+    --kubeconfig "$KUBECONFIG" \
+    --imagetemplate "$TEST_IMAGE_TEMPLATE" \
+    --enable-alpha \
+    --https \
+    --skip-cleanup-on-fail \
+    --resolvabledomain || failed=1
+
+  # Allow to use any seccompProfile for non default cases,
+  # for more check https://docs.openshift.com/container-platform/4.12/authentication/managing-security-context-constraints.html
+  oc adm policy add-scc-to-user privileged -z default -n serving-tests
+
+  # Verify that non secure settings are allowed, although not-recommended.
+  # It requires scc privileged or a custom scc that allows any seccompProfile to be set.
+  go_test_e2e -timeout=10m ./test/e2e/securedefaults -run "^(TestUnsafePermitted)$" \
+    --kubeconfig "$KUBECONFIG" \
+    --imagetemplate "$TEST_IMAGE_TEMPLATE" \
+    --enable-alpha \
+    --https \
+    --skip-cleanup-on-fail \
+    --resolvabledomain || failed=1
+
 
   return $failed
 }

--- a/openshift/patches/010-secure-pod-defaults.patch
+++ b/openshift/patches/010-secure-pod-defaults.patch
@@ -1,0 +1,114 @@
+diff --git a/pkg/apis/serving/v1/revision_defaults.go b/pkg/apis/serving/v1/revision_defaults.go
+index 8acbf3446..48c439b4a 100644
+--- a/pkg/apis/serving/v1/revision_defaults.go
++++ b/pkg/apis/serving/v1/revision_defaults.go
+@@ -184,21 +184,14 @@ func (rs *RevisionSpec) defaultSecurityContext(psc *corev1.PodSecurityContext, c
+ 	if updatedSC.AllowPrivilegeEscalation == nil {
+ 		updatedSC.AllowPrivilegeEscalation = ptr.Bool(false)
+ 	}
+-	if psc.SeccompProfile == nil || psc.SeccompProfile.Type == "" {
+-		if updatedSC.SeccompProfile == nil {
+-			updatedSC.SeccompProfile = &corev1.SeccompProfile{}
+-		}
+-		if updatedSC.SeccompProfile.Type == "" {
+-			updatedSC.SeccompProfile.Type = corev1.SeccompProfileTypeRuntimeDefault
+-		}
+-	}
++
+ 	if updatedSC.Capabilities == nil {
+ 		updatedSC.Capabilities = &corev1.Capabilities{}
+ 		updatedSC.Capabilities.Drop = []corev1.Capability{"ALL"}
+ 		// Default in NET_BIND_SERVICE to allow binding to low-numbered ports.
+ 		needsLowPort := false
+ 		for _, p := range container.Ports {
+-			if p.ContainerPort < 1024 {
++			if p.ContainerPort > 0 && p.ContainerPort < 1024 {
+ 				needsLowPort = true
+ 				break
+ 			}
+@@ -207,7 +200,9 @@ func (rs *RevisionSpec) defaultSecurityContext(psc *corev1.PodSecurityContext, c
+ 			updatedSC.Capabilities.Add = []corev1.Capability{"NET_BIND_SERVICE"}
+ 		}
+ 	}
+-
++	if psc.RunAsNonRoot == nil && updatedSC.RunAsNonRoot == nil {
++		updatedSC.RunAsNonRoot = ptr.Bool(true)
++	}
+ 	if *updatedSC != (corev1.SecurityContext{}) {
+ 		container.SecurityContext = updatedSC
+ 	}
+diff --git a/pkg/apis/serving/v1/revision_defaults_test.go b/pkg/apis/serving/v1/revision_defaults_test.go
+index 332fecfb4..401cac325 100644
+--- a/pkg/apis/serving/v1/revision_defaults_test.go
++++ b/pkg/apis/serving/v1/revision_defaults_test.go
+@@ -901,9 +901,7 @@ func TestRevisionDefaulting(t *testing.T) {
+ 						Resources:      defaultResources,
+ 						SecurityContext: &corev1.SecurityContext{
+ 							AllowPrivilegeEscalation: ptr.Bool(false),
+-							SeccompProfile: &corev1.SeccompProfile{
+-								Type: corev1.SeccompProfileTypeRuntimeDefault,
+-							},
++							RunAsNonRoot:             ptr.Bool(true),
+ 							Capabilities: &corev1.Capabilities{
+ 								Drop: []corev1.Capability{"ALL"},
+ 								Add:  []corev1.Capability{"NET_BIND_SERVICE"},
+@@ -914,9 +912,7 @@ func TestRevisionDefaulting(t *testing.T) {
+ 						Resources: defaultResources,
+ 						SecurityContext: &corev1.SecurityContext{
+ 							AllowPrivilegeEscalation: ptr.Bool(false),
+-							SeccompProfile: &corev1.SeccompProfile{
+-								Type: corev1.SeccompProfileTypeRuntimeDefault,
+-							},
++							RunAsNonRoot:             ptr.Bool(true),
+ 							Capabilities: &corev1.Capabilities{
+ 								Drop: []corev1.Capability{"ALL"},
+ 							},
+@@ -926,9 +922,7 @@ func TestRevisionDefaulting(t *testing.T) {
+ 						Resources: defaultResources,
+ 						SecurityContext: &corev1.SecurityContext{
+ 							AllowPrivilegeEscalation: ptr.Bool(true),
+-							SeccompProfile: &corev1.SeccompProfile{
+-								Type: corev1.SeccompProfileTypeRuntimeDefault,
+-							},
++							RunAsNonRoot:             ptr.Bool(true),
+ 							Capabilities: &corev1.Capabilities{
+ 								Add:  []corev1.Capability{"NET_ADMIN"},
+ 								Drop: []corev1.Capability{},
+@@ -943,6 +937,7 @@ func TestRevisionDefaulting(t *testing.T) {
+ 								Type:             corev1.SeccompProfileTypeLocalhost,
+ 								LocalhostProfile: ptr.String("special"),
+ 							},
++							RunAsNonRoot: ptr.Bool(true),
+ 							Capabilities: &corev1.Capabilities{
+ 								Add: []corev1.Capability{"NET_ADMIN"},
+ 							},
+@@ -1001,6 +996,7 @@ func TestRevisionDefaulting(t *testing.T) {
+ 						Resources:      defaultResources,
+ 						SecurityContext: &corev1.SecurityContext{
+ 							AllowPrivilegeEscalation: ptr.Bool(false),
++							RunAsNonRoot:             ptr.Bool(true),
+ 							Capabilities: &corev1.Capabilities{
+ 								Drop: []corev1.Capability{"ALL"},
+ 							},
+@@ -1010,6 +1006,7 @@ func TestRevisionDefaulting(t *testing.T) {
+ 						Name: "init",
+ 						SecurityContext: &corev1.SecurityContext{
+ 							AllowPrivilegeEscalation: ptr.Bool(false),
++							RunAsNonRoot:             ptr.Bool(true),
+ 							Capabilities: &corev1.Capabilities{
+ 								Drop: []corev1.Capability{"ALL"},
+ 							},
+diff --git a/test/e2e/securedefaults/secure_pod_defaults_test.go b/test/e2e/securedefaults/secure_pod_defaults_test.go
+index af1498dee..96e4839a9 100644
+--- a/test/e2e/securedefaults/secure_pod_defaults_test.go
++++ b/test/e2e/securedefaults/secure_pod_defaults_test.go
+@@ -60,9 +60,6 @@ func TestSecureDefaults(t *testing.T) {
+ 	if revisionSC.AllowPrivilegeEscalation == nil || *revisionSC.AllowPrivilegeEscalation {
+ 		t.Errorf("Expected allowPrivilegeEscalation: false, got %v", revisionSC.AllowPrivilegeEscalation)
+ 	}
+-	if revisionSC.SeccompProfile == nil || revisionSC.SeccompProfile.Type != v1.SeccompProfileTypeRuntimeDefault {
+-		t.Errorf("Expected seccompProfile to be RuntimeDefault, got: %v", revisionSC.SeccompProfile)
+-	}
+ }
+
+ func TestUnsafePermitted(t *testing.T) {

--- a/pkg/apis/serving/v1/revision_defaults.go
+++ b/pkg/apis/serving/v1/revision_defaults.go
@@ -184,21 +184,14 @@ func (rs *RevisionSpec) defaultSecurityContext(psc *corev1.PodSecurityContext, c
 	if updatedSC.AllowPrivilegeEscalation == nil {
 		updatedSC.AllowPrivilegeEscalation = ptr.Bool(false)
 	}
-	if psc.SeccompProfile == nil || psc.SeccompProfile.Type == "" {
-		if updatedSC.SeccompProfile == nil {
-			updatedSC.SeccompProfile = &corev1.SeccompProfile{}
-		}
-		if updatedSC.SeccompProfile.Type == "" {
-			updatedSC.SeccompProfile.Type = corev1.SeccompProfileTypeRuntimeDefault
-		}
-	}
+
 	if updatedSC.Capabilities == nil {
 		updatedSC.Capabilities = &corev1.Capabilities{}
 		updatedSC.Capabilities.Drop = []corev1.Capability{"ALL"}
 		// Default in NET_BIND_SERVICE to allow binding to low-numbered ports.
 		needsLowPort := false
 		for _, p := range container.Ports {
-			if p.ContainerPort < 1024 {
+			if p.ContainerPort > 0 && p.ContainerPort < 1024 {
 				needsLowPort = true
 				break
 			}
@@ -207,7 +200,9 @@ func (rs *RevisionSpec) defaultSecurityContext(psc *corev1.PodSecurityContext, c
 			updatedSC.Capabilities.Add = []corev1.Capability{"NET_BIND_SERVICE"}
 		}
 	}
-
+	if psc.RunAsNonRoot == nil && updatedSC.RunAsNonRoot == nil {
+		updatedSC.RunAsNonRoot = ptr.Bool(true)
+	}
 	if *updatedSC != (corev1.SecurityContext{}) {
 		container.SecurityContext = updatedSC
 	}

--- a/pkg/apis/serving/v1/revision_defaults.go
+++ b/pkg/apis/serving/v1/revision_defaults.go
@@ -188,17 +188,6 @@ func (rs *RevisionSpec) defaultSecurityContext(psc *corev1.PodSecurityContext, c
 	if updatedSC.Capabilities == nil {
 		updatedSC.Capabilities = &corev1.Capabilities{}
 		updatedSC.Capabilities.Drop = []corev1.Capability{"ALL"}
-		// Default in NET_BIND_SERVICE to allow binding to low-numbered ports.
-		needsLowPort := false
-		for _, p := range container.Ports {
-			if p.ContainerPort > 0 && p.ContainerPort < 1024 {
-				needsLowPort = true
-				break
-			}
-		}
-		if updatedSC.Capabilities.Add == nil && needsLowPort {
-			updatedSC.Capabilities.Add = []corev1.Capability{"NET_BIND_SERVICE"}
-		}
 	}
 	if psc.RunAsNonRoot == nil && updatedSC.RunAsNonRoot == nil {
 		updatedSC.RunAsNonRoot = ptr.Bool(true)

--- a/pkg/apis/serving/v1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1/revision_defaults_test.go
@@ -901,9 +901,7 @@ func TestRevisionDefaulting(t *testing.T) {
 						Resources:      defaultResources,
 						SecurityContext: &corev1.SecurityContext{
 							AllowPrivilegeEscalation: ptr.Bool(false),
-							SeccompProfile: &corev1.SeccompProfile{
-								Type: corev1.SeccompProfileTypeRuntimeDefault,
-							},
+							RunAsNonRoot:             ptr.Bool(true),
 							Capabilities: &corev1.Capabilities{
 								Drop: []corev1.Capability{"ALL"},
 								Add:  []corev1.Capability{"NET_BIND_SERVICE"},
@@ -914,9 +912,7 @@ func TestRevisionDefaulting(t *testing.T) {
 						Resources: defaultResources,
 						SecurityContext: &corev1.SecurityContext{
 							AllowPrivilegeEscalation: ptr.Bool(false),
-							SeccompProfile: &corev1.SeccompProfile{
-								Type: corev1.SeccompProfileTypeRuntimeDefault,
-							},
+							RunAsNonRoot:             ptr.Bool(true),
 							Capabilities: &corev1.Capabilities{
 								Drop: []corev1.Capability{"ALL"},
 							},
@@ -926,9 +922,7 @@ func TestRevisionDefaulting(t *testing.T) {
 						Resources: defaultResources,
 						SecurityContext: &corev1.SecurityContext{
 							AllowPrivilegeEscalation: ptr.Bool(true),
-							SeccompProfile: &corev1.SeccompProfile{
-								Type: corev1.SeccompProfileTypeRuntimeDefault,
-							},
+							RunAsNonRoot:             ptr.Bool(true),
 							Capabilities: &corev1.Capabilities{
 								Add:  []corev1.Capability{"NET_ADMIN"},
 								Drop: []corev1.Capability{},
@@ -943,6 +937,7 @@ func TestRevisionDefaulting(t *testing.T) {
 								Type:             corev1.SeccompProfileTypeLocalhost,
 								LocalhostProfile: ptr.String("special"),
 							},
+							RunAsNonRoot: ptr.Bool(true),
 							Capabilities: &corev1.Capabilities{
 								Add: []corev1.Capability{"NET_ADMIN"},
 							},
@@ -1001,6 +996,7 @@ func TestRevisionDefaulting(t *testing.T) {
 						Resources:      defaultResources,
 						SecurityContext: &corev1.SecurityContext{
 							AllowPrivilegeEscalation: ptr.Bool(false),
+							RunAsNonRoot:             ptr.Bool(true),
 							Capabilities: &corev1.Capabilities{
 								Drop: []corev1.Capability{"ALL"},
 							},
@@ -1010,6 +1006,7 @@ func TestRevisionDefaulting(t *testing.T) {
 						Name: "init",
 						SecurityContext: &corev1.SecurityContext{
 							AllowPrivilegeEscalation: ptr.Bool(false),
+							RunAsNonRoot:             ptr.Bool(true),
 							Capabilities: &corev1.Capabilities{
 								Drop: []corev1.Capability{"ALL"},
 							},

--- a/pkg/apis/serving/v1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1/revision_defaults_test.go
@@ -904,7 +904,6 @@ func TestRevisionDefaulting(t *testing.T) {
 							RunAsNonRoot:             ptr.Bool(true),
 							Capabilities: &corev1.Capabilities{
 								Drop: []corev1.Capability{"ALL"},
-								Add:  []corev1.Capability{"NET_BIND_SERVICE"},
 							},
 						},
 					}, {

--- a/test/e2e/securedefaults/secure_pod_defaults_test.go
+++ b/test/e2e/securedefaults/secure_pod_defaults_test.go
@@ -60,9 +60,6 @@ func TestSecureDefaults(t *testing.T) {
 	if revisionSC.AllowPrivilegeEscalation == nil || *revisionSC.AllowPrivilegeEscalation {
 		t.Errorf("Expected allowPrivilegeEscalation: false, got %v", revisionSC.AllowPrivilegeEscalation)
 	}
-	if revisionSC.SeccompProfile == nil || revisionSC.SeccompProfile.Type != v1.SeccompProfileTypeRuntimeDefault {
-		t.Errorf("Expected seccompProfile to be RuntimeDefault, got: %v", revisionSC.SeccompProfile)
-	}
 }
 
 func TestUnsafePermitted(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

- Adds security pod defaults support as we have for main (note: this requires less work than 1.8 which lacks all logic).
- Unblocks #201

**Which issue(s) this PR fixes**:

JIRA: 

**Does this PR needs for other branches**:

<!--
If no, just write "NONE".
If yes, add cherry-pick label:

/cherry-pick release-vX.Y
-->
NONE

**Does this PR (patch) needs to update/drop in the future?**:

<!--
If no, just write "NONE".
If yes, please open the JIRA and link here:
-->
NONE

