### PR TITLE
[RELEASE 1.7] [SRVKS-1044] Don't set fields injected by PSA

### DIFF
--- a/pkg/apis/serving/v1/revision_defaults.go
+++ b/pkg/apis/serving/v1/revision_defaults.go
@@ -206,11 +206,6 @@ func (rs *RevisionSpec) defaultSecurityContext(psc *corev1.PodSecurityContext, c
 		updatedSC.AllowPrivilegeEscalation = ptr.Bool(false)
 	}
 
-	if updatedSC.Capabilities == nil {
-		updatedSC.Capabilities = &corev1.Capabilities{}
-		updatedSC.Capabilities.Drop = []corev1.Capability{"ALL"}
-	}
-
 	if *updatedSC != (corev1.SecurityContext{}) {
 		container.SecurityContext = updatedSC
 	}

--- a/pkg/apis/serving/v1/revision_defaults.go
+++ b/pkg/apis/serving/v1/revision_defaults.go
@@ -210,9 +210,7 @@ func (rs *RevisionSpec) defaultSecurityContext(psc *corev1.PodSecurityContext, c
 		updatedSC.Capabilities = &corev1.Capabilities{}
 		updatedSC.Capabilities.Drop = []corev1.Capability{"ALL"}
 	}
-	if psc.RunAsNonRoot == nil && updatedSC.RunAsNonRoot == nil {
-		updatedSC.RunAsNonRoot = ptr.Bool(true)
-	}
+
 	if *updatedSC != (corev1.SecurityContext{}) {
 		container.SecurityContext = updatedSC
 	}

--- a/pkg/apis/serving/v1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1/revision_defaults_test.go
@@ -901,7 +901,6 @@ func TestRevisionDefaulting(t *testing.T) {
 						Resources:      defaultResources,
 						SecurityContext: &corev1.SecurityContext{
 							AllowPrivilegeEscalation: ptr.Bool(false),
-							RunAsNonRoot:             ptr.Bool(true),
 							Capabilities: &corev1.Capabilities{
 								Drop: []corev1.Capability{"ALL"},
 							},
@@ -911,7 +910,6 @@ func TestRevisionDefaulting(t *testing.T) {
 						Resources: defaultResources,
 						SecurityContext: &corev1.SecurityContext{
 							AllowPrivilegeEscalation: ptr.Bool(false),
-							RunAsNonRoot:             ptr.Bool(true),
 							Capabilities: &corev1.Capabilities{
 								Drop: []corev1.Capability{"ALL"},
 							},
@@ -921,7 +919,6 @@ func TestRevisionDefaulting(t *testing.T) {
 						Resources: defaultResources,
 						SecurityContext: &corev1.SecurityContext{
 							AllowPrivilegeEscalation: ptr.Bool(true),
-							RunAsNonRoot:             ptr.Bool(true),
 							Capabilities: &corev1.Capabilities{
 								Add:  []corev1.Capability{"NET_ADMIN"},
 								Drop: []corev1.Capability{},
@@ -936,7 +933,6 @@ func TestRevisionDefaulting(t *testing.T) {
 								Type:             corev1.SeccompProfileTypeLocalhost,
 								LocalhostProfile: ptr.String("special"),
 							},
-							RunAsNonRoot: ptr.Bool(true),
 							Capabilities: &corev1.Capabilities{
 								Add: []corev1.Capability{"NET_ADMIN"},
 							},
@@ -995,7 +991,6 @@ func TestRevisionDefaulting(t *testing.T) {
 						Resources:      defaultResources,
 						SecurityContext: &corev1.SecurityContext{
 							AllowPrivilegeEscalation: ptr.Bool(false),
-							RunAsNonRoot:             ptr.Bool(true),
 							Capabilities: &corev1.Capabilities{
 								Drop: []corev1.Capability{"ALL"},
 							},
@@ -1005,7 +1000,6 @@ func TestRevisionDefaulting(t *testing.T) {
 						Name: "init",
 						SecurityContext: &corev1.SecurityContext{
 							AllowPrivilegeEscalation: ptr.Bool(false),
-							RunAsNonRoot:             ptr.Bool(true),
 							Capabilities: &corev1.Capabilities{
 								Drop: []corev1.Capability{"ALL"},
 							},

--- a/pkg/apis/serving/v1/revision_defaults_test.go
+++ b/pkg/apis/serving/v1/revision_defaults_test.go
@@ -901,18 +901,12 @@ func TestRevisionDefaulting(t *testing.T) {
 						Resources:      defaultResources,
 						SecurityContext: &corev1.SecurityContext{
 							AllowPrivilegeEscalation: ptr.Bool(false),
-							Capabilities: &corev1.Capabilities{
-								Drop: []corev1.Capability{"ALL"},
-							},
 						},
 					}, {
 						Name:      "sidecar",
 						Resources: defaultResources,
 						SecurityContext: &corev1.SecurityContext{
 							AllowPrivilegeEscalation: ptr.Bool(false),
-							Capabilities: &corev1.Capabilities{
-								Drop: []corev1.Capability{"ALL"},
-							},
 						},
 					}, {
 						Name:      "special-sidecar",
@@ -991,18 +985,12 @@ func TestRevisionDefaulting(t *testing.T) {
 						Resources:      defaultResources,
 						SecurityContext: &corev1.SecurityContext{
 							AllowPrivilegeEscalation: ptr.Bool(false),
-							Capabilities: &corev1.Capabilities{
-								Drop: []corev1.Capability{"ALL"},
-							},
 						},
 					}},
 					InitContainers: []corev1.Container{{
 						Name: "init",
 						SecurityContext: &corev1.SecurityContext{
 							AllowPrivilegeEscalation: ptr.Bool(false),
-							Capabilities: &corev1.Capabilities{
-								Drop: []corev1.Capability{"ALL"},
-							},
 						},
 					}},
 					SecurityContext: &corev1.PodSecurityContext{

--- a/test/e2e/securedefaults/secure_pod_defaults_test.go
+++ b/test/e2e/securedefaults/secure_pod_defaults_test.go
@@ -54,9 +54,7 @@ func TestSecureDefaults(t *testing.T) {
 	if revisionSC == nil {
 		t.Fatal("Container SecurityContext was nil, should have been defaulted.")
 	}
-	if len(revisionSC.Capabilities.Drop) != 1 || revisionSC.Capabilities.Drop[0] != "ALL" {
-		t.Errorf("Expected to Drop 'ALL' capability: %v", revisionSC.Capabilities)
-	}
+
 	if revisionSC.AllowPrivilegeEscalation == nil || *revisionSC.AllowPrivilegeEscalation {
 		t.Errorf("Expected allowPrivilegeEscalation: false, got %v", revisionSC.AllowPrivilegeEscalation)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
- OCP injects runAsNonRoot set to true, capabilities: drop: ALL  by default (tested on 4.13).

Here is output of what is being injected by default without security-pod-defaults enabled, just by PSA: https://gist.github.com/skonto/ae14a08a3961a4c373b7a2b211dbebbc 

- If we dont set defaults we dont need to add anything for the privileged ports scenario and also we get the workloads run with restricted-v2.

- Verified that by not setting the defaults in this PR we avoid the issue in SRVKS-1044.
The values are injected by OCP PSA so users dont need to enable the feature at all.
The only warning I see on 4.13 is the one reported in SRVKS-985 about seccompProfile which is an OCP bug to be fixed in 4.13+.


> {"severity":"WARNING","timestamp":"2023-03-23T14:53:38.870371231Z","logger":"controller","caller":"logging/warning_handler.go:32","message":"API Warning: would violate PodSecurity \"restricted:latest\": seccompProfile (pod or containers \"user-container\", \"queue-proxy\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")","commit":"ab3dd79-dirty","knative.dev/pod":"controller-79c6f466dc-r9bm9"}



On low versions eg. 4.11 I get:


> {"severity":"WARNING","timestamp":"2023-03-23T16:00:34.162152946Z","logger":"controller","caller":"logging/warning_handler.go:32","message":"API Warning: would violate PodSecurity \"restricted:v1.24\": allowPrivilegeEscalation != false (container \"user-container\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container \"user-container\" must set securityContext.capabilities.drop=[\"ALL\"]), runAsNonRoot != true (pod or container \"user-container\" must set securityContext.runAsNonRoot=true), seccompProfile (pod or containers \"user-container\", \"queue-proxy\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")","commit":"ab3dd79-dirty","knative.dev/pod":"controller-64f8b9865-hfx8q"}


- Getting the audit logs didnt show any different, only the above warning.

**Which issue(s) this PR fixes**:

JIRA: https://issues.redhat.com/browse/SRVKS-1044

**Does this PR needs for other branches**:

<!--
If no, just write "NONE".
If yes, add cherry-pick label:

/cherry-pick release-v1.8
-->
/cherry-pick release-v1.8
/cherry-pick release-v1.9

**Does this PR (patch) needs to update/drop in the future?**:

<!--
If no, just write "NONE".
If yes, please open the JIRA and link here:
-->

JIRA: 
