### PR TITLE
Update golang version to 1.19

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -21,9 +21,9 @@ jobs:
       GOPATH: ${{ github.workspace }}
     steps:
       - name: Setup Golang
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -53,10 +53,10 @@ jobs:
     env:
       GOPATH: ${{ github.workspace }}
     steps:
-      - name: Set up Go 1.18.x
-        uses: actions/setup-go@v2
+      - name: Set up Go 1.19.x
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.18.x
+          go-version: 1.19.x
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/openshift/ci-operator/Dockerfile.in
+++ b/openshift/ci-operator/Dockerfile.in
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 
 COPY . .
 RUN make install test-install

--- a/openshift/ci-operator/Dockerfile_with_kodata.in
+++ b/openshift/ci-operator/Dockerfile_with_kodata.in
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.18 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 
 COPY . .
 RUN make install test-install

--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to bootstrap build and test in openshift-ci
 
-FROM registry.ci.openshift.org/openshift/release:golang-1.18
+FROM registry.ci.openshift.org/openshift/release:golang-1.19
 
 # Add kubernetes repository
 ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/


### PR DESCRIPTION
**What this PR does / why we need it**:
- Updates golang version to 1.19
- Fixes build errors when using S-O script on golang 1.19

**Which issue(s) this PR fixes**:

JIRA: SRVCOM-2370

**Does this PR needs for other branches**:

NONE

**Does this PR (patch) needs to update/drop in the future?**:

NONE

