### PR TITLE
Revert update golang version to 1.19 for github-action

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -21,9 +21,9 @@ jobs:
       GOPATH: ${{ github.workspace }}
     steps:
       - name: Setup Golang
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v2
         with:
-          go-version: 1.19.x
+          go-version: 1.18.x
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -53,10 +53,10 @@ jobs:
     env:
       GOPATH: ${{ github.workspace }}
     steps:
-      - name: Set up Go 1.19.x
-        uses: actions/setup-go@v4
+      - name: Set up Go 1.18.x
+        uses: actions/setup-go@v2
         with:
-          go-version: 1.19.x
+          go-version: 1.18.x
 
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
As per slack discussion: https://redhat-internal.slack.com/archives/CF5ANN61F/p1680251118091129?thread_ts=1680244739.280449&cid=CF5ANN61F

## Changes
- Partially reverts https://github.com/openshift-knative/serving/pull/243.
