### PR TITLE
Delete the created golang cache directory during docker build

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -10,5 +10,9 @@ RUN yum install -y kubectl httpd-tools
 RUN GOFLAGS='' go install github.com/mikefarah/yq/v3@latest
 RUN GOFLAGS='' go install knative.dev/test-infra/tools/kntest/cmd/kntest@latest
 
+# go install creates $GOPATH/.cache with root permissions, we delete it here
+# to avoid permission issues with the runtime users
+RUN rm -rf $GOPATH/.cache
+
 # Allow runtime users to add entries to /etc/passwd
 RUN chmod g+rw /etc/passwd


### PR DESCRIPTION
Context: https://redhat-internal.slack.com/archives/CF5ANN61F/p1680593054650179 and https://redhat-internal.slack.com/archives/CLUCMK7R6/p1680505313286459

## Changes
```
RUN GOFLAGS='' go install github.com/mikefarah/yq/v3@latest
RUN GOFLAGS='' go install knative.dev/test-infra/tools/kntest/cmd/kntest@latest
```
creates a $GOPATH/.cache directory with permissions of `root`. To avoid issues when this image is run with an OCP runtime user, we have to delete the created folder again. It will be recreated by golang on the first use with the permissions of the runtime user.

/cc @mgencur, @skonto 