### PR TITLE
Revert to golang 1.18

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -10,9 +10,5 @@ RUN yum install -y kubectl httpd-tools
 RUN GOFLAGS='' go install github.com/mikefarah/yq/v3@latest
 RUN GOFLAGS='' go install knative.dev/test-infra/tools/kntest/cmd/kntest@latest
 
-# go install creates $GOPATH/.cache with root permissions, we delete it here
-# to avoid permission issues with the runtime users
-RUN rm -rf $GOPATH/.cache
-
 # Allow runtime users to add entries to /etc/passwd
 RUN chmod g+rw /etc/passwd

--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to bootstrap build and test in openshift-ci
 
-FROM registry.ci.openshift.org/openshift/release:golang-1.19
+FROM registry.ci.openshift.org/openshift/release:golang-1.18
 
 # Add kubernetes repository
 ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/


### PR DESCRIPTION
## Changes
- This PR reverts the bump to golang 1.19 to see if this is related to the CI-issues.
- Context: https://redhat-internal.slack.com/archives/CF5ANN61F/p1680614138940309
