### PR TITLE
[RELEASE-1.8] wait for config-map changes to be propagated for builds to work on golang 1.19

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -295,6 +295,8 @@ function run_e2e_tests(){
   # Run init-containers test
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"kubernetes.podspec-volumes-emptydir": "enabled"}}}}' || fail_test
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"kubernetes.podspec-init-containers": "enabled"}}}}' || fail_test
+  timeout 30 '[[ $(oc get cm -n $SERVING_NAMESPACE config-features -o jsonpath={.data.kubernetes.podspec-volumes-emptydir}) == "enabled" ]]' || fail_test
+  timeout 30 '[[ $(oc get cm -n $SERVING_NAMESPACE config-features -o jsonpath={.data.kubernetes.podspec-init-containers}) == "enabled" ]]' || fail_test
   go_test_e2e -timeout=2m ./test/e2e/initcontainers \
     --kubeconfig "$KUBECONFIG" \
     --imagetemplate "$TEST_IMAGE_TEMPLATE" \
@@ -303,6 +305,8 @@ function run_e2e_tests(){
     --resolvabledomain || failed=1
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"kubernetes.podspec-volumes-emptydir": "disabled"}}}}' || fail_test
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"kubernetes.podspec-init-containers": "disabled"}}}}' || fail_test
+  timeout 30 '[[ $(oc get cm -n $SERVING_NAMESPACE config-features -o jsonpath={.data.kubernetes.podspec-volumes-emptydir}) == "disabled" ]]' || fail_test
+  timeout 30 '[[ $(oc get cm -n $SERVING_NAMESPACE config-features -o jsonpath={.data.kubernetes.podspec-init-containers}) == "disabled" ]]' || fail_test
 
   # Run PVC test
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"kubernetes.podspec-persistent-volume-claim": "enabled"}}}}' || fail_test

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -297,6 +297,7 @@ function run_e2e_tests(){
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"kubernetes.podspec-init-containers": "enabled"}}}}' || fail_test
   timeout 30 '[[ $(oc get cm -n $SERVING_NAMESPACE config-features -o jsonpath={.data.kubernetes.podspec-volumes-emptydir}) == "enabled" ]]' || fail_test
   timeout 30 '[[ $(oc get cm -n $SERVING_NAMESPACE config-features -o jsonpath={.data.kubernetes.podspec-init-containers}) == "enabled" ]]' || fail_test
+  sleep 30
   go_test_e2e -timeout=2m ./test/e2e/initcontainers \
     --kubeconfig "$KUBECONFIG" \
     --imagetemplate "$TEST_IMAGE_TEMPLATE" \
@@ -307,6 +308,7 @@ function run_e2e_tests(){
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"kubernetes.podspec-init-containers": "disabled"}}}}' || fail_test
   timeout 30 '[[ $(oc get cm -n $SERVING_NAMESPACE config-features -o jsonpath={.data.kubernetes.podspec-volumes-emptydir}) == "disabled" ]]' || fail_test
   timeout 30 '[[ $(oc get cm -n $SERVING_NAMESPACE config-features -o jsonpath={.data.kubernetes.podspec-init-containers}) == "disabled" ]]' || fail_test
+  sleep 30
 
   # Run PVC test
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"kubernetes.podspec-persistent-volume-claim": "enabled"}}}}' || fail_test

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -314,6 +314,7 @@ function run_e2e_tests(){
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"kubernetes.podspec-persistent-volume-claim": "enabled"}}}}' || fail_test
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"kubernetes.podspec-persistent-volume-write": "enabled"}}}}' || fail_test
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"kubernetes.podspec-securitycontext": "enabled"}}}}' || fail_test
+  sleep 30
   go_test_e2e -timeout=5m ./test/e2e/pvc \
     --kubeconfig "$KUBECONFIG" \
     --imagetemplate "$TEST_IMAGE_TEMPLATE" \
@@ -324,6 +325,7 @@ function run_e2e_tests(){
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"kubernetes.podspec-persistent-volume-claim": "disabled"}}}}' || fail_test
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"kubernetes.podspec-persistent-volume-write": "disabled"}}}}' || fail_test
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"kubernetes.podspec-securitycontext": "disabled"}}}}' || fail_test
+  sleep 30
 
   # Run the helloworld test with an image pulled into the internal registry.
   local image_to_tag=$KNATIVE_SERVING_TEST_HELLOWORLD


### PR DESCRIPTION
## Changes
- Wait for config-map changes to be propagated for builds to work on golang 1.19
- Context: https://redhat-internal.slack.com/archives/CF5ANN61F/p1680614138940309