### PR TITLE
[RELEASE-1.9] wait for config-map changes to be propagated for builds to work on golang 1.19

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -10,5 +10,9 @@ RUN yum install -y kubectl httpd-tools
 RUN GOFLAGS='' go install github.com/mikefarah/yq/v3@latest
 RUN GOFLAGS='' go install knative.dev/test-infra/tools/kntest/cmd/kntest@latest
 
+# go install creates $GOPATH/.cache with root permissions, we delete it here
+# to avoid permission issues with the runtime users
+RUN rm -rf $GOPATH/.cache
+
 # Allow runtime users to add entries to /etc/passwd
 RUN chmod g+rw /etc/passwd

--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to bootstrap build and test in openshift-ci
 
-FROM registry.ci.openshift.org/openshift/release:golang-1.18
+FROM registry.ci.openshift.org/openshift/release:golang-1.19
 
 # Add kubernetes repository
 ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -295,6 +295,9 @@ function run_e2e_tests(){
   # Run init-containers test
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"kubernetes.podspec-volumes-emptydir": "enabled"}}}}' || fail_test
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"kubernetes.podspec-init-containers": "enabled"}}}}' || fail_test
+  timeout 30 '[[ $(oc get cm -n $SERVING_NAMESPACE config-features -o jsonpath={.data.kubernetes.podspec-volumes-emptydir}) == "enabled" ]]' || fail_test
+  timeout 30 '[[ $(oc get cm -n $SERVING_NAMESPACE config-features -o jsonpath={.data.kubernetes.podspec-init-containers}) == "enabled" ]]' || fail_test
+  sleep 30
   go_test_e2e -timeout=2m ./test/e2e/initcontainers \
     --kubeconfig "$KUBECONFIG" \
     --imagetemplate "$TEST_IMAGE_TEMPLATE" \
@@ -303,11 +306,15 @@ function run_e2e_tests(){
     --resolvabledomain || failed=1
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"kubernetes.podspec-volumes-emptydir": "disabled"}}}}' || fail_test
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"kubernetes.podspec-init-containers": "disabled"}}}}' || fail_test
+  timeout 30 '[[ $(oc get cm -n $SERVING_NAMESPACE config-features -o jsonpath={.data.kubernetes.podspec-volumes-emptydir}) == "disabled" ]]' || fail_test
+  timeout 30 '[[ $(oc get cm -n $SERVING_NAMESPACE config-features -o jsonpath={.data.kubernetes.podspec-init-containers}) == "disabled" ]]' || fail_test
+  sleep 30
 
   # Run PVC test
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"kubernetes.podspec-persistent-volume-claim": "enabled"}}}}' || fail_test
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"kubernetes.podspec-persistent-volume-write": "enabled"}}}}' || fail_test
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"kubernetes.podspec-securitycontext": "enabled"}}}}' || fail_test
+  sleep 30
   go_test_e2e -timeout=5m ./test/e2e/pvc \
     --kubeconfig "$KUBECONFIG" \
     --imagetemplate "$TEST_IMAGE_TEMPLATE" \
@@ -318,6 +325,7 @@ function run_e2e_tests(){
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"kubernetes.podspec-persistent-volume-claim": "disabled"}}}}' || fail_test
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"kubernetes.podspec-persistent-volume-write": "disabled"}}}}' || fail_test
   oc -n ${SYSTEM_NAMESPACE} patch knativeserving/knative-serving --type=merge --patch='{"spec": {"config": { "features": {"kubernetes.podspec-securitycontext": "disabled"}}}}' || fail_test
+  sleep 30
 
   # Run the helloworld test with an image pulled into the internal registry.
   local image_to_tag=$KNATIVE_SERVING_TEST_HELLOWORLD


### PR DESCRIPTION
## Changes
- Wait for config-map changes to be propagated for builds to work on golang 1.19
- Re-introduces the reverted https://github.com/openshift-knative/serving/commit/63387986d659730d363383af6bcb409c55fc66a6 and https://github.com/openshift-knative/serving/commit/83dce1c6c3544cc929c57450200b3a2771abb25b
- Context: https://redhat-internal.slack.com/archives/CF5ANN61F/p1680614138940309