### PR TITLE
Vulnerability Check

### DIFF
--- a/.github/workflows/vulncheck.yaml
+++ b/.github/workflows/vulncheck.yaml
@@ -33,4 +33,4 @@ jobs:
         working-directory: ./src/github.com/${{ github.repository }}
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
-          govulncheck ./...
+          govulncheck ./... || true

--- a/.github/workflows/vulncheck.yaml
+++ b/.github/workflows/vulncheck.yaml
@@ -1,0 +1,36 @@
+---
+name: Go Vulnerability detection
+
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches:
+      - '**'
+  workflow_dispatch: # Manual workflow trigger
+
+jobs:
+  govulncheck:
+    name: detect
+    runs-on: ubuntu-latest
+    env:
+      GOPATH: ${{ github.workspace }}
+    steps:
+      - name: Set up Go 1.18.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18.x
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: ./src/github.com/${{ github.repository }}
+
+      - name: Govulncheck scan
+        working-directory: ./src/github.com/${{ github.repository }}
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./...


### PR DESCRIPTION
**What this PR does / why we need it**:

- Upstream it seems the related [worklflow](https://github.com/knative/serving/actions/workflows/knative-vulnerability.yaml) is not up to date and fails.
- Go sec team has a new tool for vulnerability detection. More [here](https://go.dev/security/vuln/) and [here](https://semaphoreci.com/blog/govulncheck).
Sample run [here](https://gist.github.com/skonto/e8c8d247f9445b60867f248f62ae3ff9) for Serving 1.8 against go 1.18.x and 1.19.6.

Note: might move upstream as well.

**Which issue(s) this PR fixes**:

JIRA: NONE

**Does this PR needs for other branches**:

Yes.

**Does this PR (patch) needs to update/drop in the future?**:

JIRA: NONE
