### PR TITLE
[RELEASE-1.10] Min TLS for tag to digest defaults to 1.2 again and is configurable (#13963)

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -87,7 +87,7 @@ jobs:
           echo "${TEMP_PATH}" >> $GITHUB_PATH
 
       - name: Shellcheck
-        working-directory: ./src/github.com/${{ github.repository }}
+        working-directory: ./src/github.com/${{ github.repository }}/openshift
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
         run: |
@@ -101,19 +101,11 @@ jobs:
                 -fail-on-error="true" \
                 -level="error"
 
-      - name: Go Lint - serving
-        if: github.base_ref != 'main'
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: v1.50.1
-          args: --timeout=10m0s --verbose
-          working-directory: ./src/github.com/${{ github.repository }}
-
       # This is mostly copied from https://github.com/get-woke/woke-action-reviewdog/blob/main/entrypoint.sh
       # since their action is not yet released under a stable version.
       - name: Language
         if: ${{ always() && github.event_name == 'pull_request' }}
-        working-directory: ./src/github.com/${{ github.repository }}
+        working-directory: ./src/github.com/${{ github.repository }}/openshift
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
This patch cherry-picks https://github.com/knative/serving/commit/fc055b13ec340f4b370d2cd83fef2e8416e3a068

/cc @ReToCode @skonto 