### PR TITLE
Add lint check only for openshift specific files

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -87,7 +87,7 @@ jobs:
           echo "${TEMP_PATH}" >> $GITHUB_PATH
 
       - name: Shellcheck
-        working-directory: ./src/github.com/${{ github.repository }}
+        working-directory: ./src/github.com/${{ github.repository }}/openshift
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
         run: |
@@ -101,19 +101,11 @@ jobs:
                 -fail-on-error="true" \
                 -level="error"
 
-      - name: Go Lint - serving
-        if: github.base_ref != 'main'
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: v1.50.1
-          args: --timeout=10m0s --verbose
-          working-directory: ./src/github.com/${{ github.repository }}
-
       # This is mostly copied from https://github.com/get-woke/woke-action-reviewdog/blob/main/entrypoint.sh
       # since their action is not yet released under a stable version.
       - name: Language
         if: ${{ always() && github.event_name == 'pull_request' }}
-        working-directory: ./src/github.com/${{ github.repository }}
+        working-directory: ./src/github.com/${{ github.repository }}/openshift
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION

Add lint check only for openshift specific files

**What this PR does / why we need it**:

As downstream and upstream uses different lint (including golang version),
the cherry-picks sometimes fails - e.g.

* https://github.com/openshift-knative/serving/pull/305/checks
* https://github.com/openshift-knative/serving/actions/runs/4932757562

**Which issue(s) this PR fixes**:

* None as this is a lint issue.

**Does this PR needs for other branches**:

* https://github.com/openshift-knative/serving/pull/310 contains for release-1.10

**Does this PR (patch) needs to update/drop in the future?**:

* NONE

/cherry-pick release-v1.9