### PR TITLE
Validate GH action only on PR

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -2,11 +2,6 @@
 name: Validate
 
 on:
-  push:
-    branches:
-      - '**'
-    tags:
-      - 'v*.*.*'
   pull_request:
     branches:
       - '**'


### PR DESCRIPTION
**What this PR does / why we need it**:

It seems `{ github.base_ref }` value does not work for push event. 
It is enough to validate when PR is sent so this patch drops the push.

**Which issue(s) this PR fixes**:

NONE - just a clean up.

**Does this PR needs for other branches**:

/cherry-pick release-v1.10

**Does this PR (patch) needs to update/drop in the future?**:

NOE
