### PR TITLE
Drop unnecessary env values

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -203,9 +203,6 @@ function prepare_knative_serving_tests_nightly {
   oc adm policy add-scc-to-user anyuid -z default -n serving-tests
 
   export SYSTEM_NAMESPACE="$SERVING_NAMESPACE"
-  export GATEWAY_OVERRIDE=kourier
-  export GATEWAY_NAMESPACE_OVERRIDE="$SERVING_INGRESS_NAMESPACE"
-  export INGRESS_CLASS=kourier.ingress.networking.knative.dev
 
   if [[ ${ENABLE_INTERNAL_TLS} == "true" ]]; then
     # Deploy CA cert for testing TLS with cluster-local gateway


### PR DESCRIPTION
What this PR does / why we need it:

This is just same with https://github.com/openshift-knative/serverless-operator/pull/2105
`INGRESS_CLASS` is also not necessary.

Which issue(s) this PR fixes:

NONE - just a clean up.

Does this PR needs for other branches:

NONE

Does this PR (patch) needs to update/drop in the future?:

NONE