### PR TITLE
[SRVKS-1071] Add github action to sync upstream

### DIFF
--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -1,0 +1,45 @@
+---
+name: Sync upstream
+
+on:
+  workflow_dispatch: # Manual workflow trigger
+
+jobs:
+  sync-upstream:
+    if: github.event.created || github.event_name == 'workflow_dispatch'
+    name:
+    runs-on: ubuntu-latest
+    env:
+      GOPATH: ${{ github.workspace }}
+      UPSTREAM: https://github.com/knative/serving.git
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: ./src/github.com/${{ github.repository }}
+          fetch-depth: 0
+      - name: Sync upstream
+        working-directory: ./src/github.com/${{ github.repository }}
+        run: |
+          git remote add upstream "${UPSTREAM}"
+          git fetch upstream
+          # upstream's base_ref has "v" like release-v1.10
+          BRANCH=${{ github.ref_name }}
+          git merge upstream/"release-${BRANCH#release-v}"
+
+        shell: bash
+
+      - name: Regenerate all generated files
+        working-directory: ./src/github.com/${{ github.repository }}
+        run: ./openshift/release/generate-release.sh ${{ github.ref_name }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          path: ./src/github.com/${{ github.repository }}
+          branch: auto/sync-upstream-${{ github.ref_name }}
+          title: "[${{ github.ref_name }}] Sync upstream release"
+          commit-message: "Sync upstream release"
+          delete-branch: true
+          body: |
+            Sync upstream release

--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -23,7 +23,7 @@ jobs:
         run: |
           git remote add upstream "${UPSTREAM}"
           git fetch upstream
-          # upstream's base_ref has "v" like release-v1.10
+          # upstream's branch does not have "v" like release-1.10. We need to cut.
           BRANCH=${{ github.ref_name }}
           git merge upstream/"release-${BRANCH#release-v}"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently we are manually pulling the minor release after the downstream cut - e.g. https://github.com/openshift-knative/net-istio/pull/24
It should be done by GH action.

**Which issue(s) this PR fixes**:

JIRA: SRVKS-1071

**Does this PR needs for other branches**:

/cherry-pick release-v1.9
/cherry-pick main

**Does this PR (patch) needs to update/drop in the future?**:

NONE
