### PR TITLE
Add github user name

### DIFF
--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -28,6 +28,12 @@ jobs:
       - name: Sync upstream
         working-directory: ./src/github.com/${{ github.repository }}
         run: |
+          if ! git config user.name > /dev/null; then
+            git config user.name "John Doe"
+          fi
+          if ! git config user.email > /dev/null; then
+            git config user.email "johndoe@localhost"
+          fi
           git remote add upstream "${UPSTREAM}"
           git fetch upstream
           BRANCH=${{ inputs.release }}


### PR DESCRIPTION
This is a fix to run `git remote add` on github action.
It fails without this setting - https://github.com/openshift-knative/serving/actions/runs/5198421715/jobs/9374511129