### PR TITLE
Remove podspec-volumes-emptydir toggle

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -247,7 +247,6 @@ function run_e2e_tests(){
   enable_feature_flags secure-pod-defaults || fail_test
 
   if [ -n "$test_name" ]; then
-    enable_feature_flags kubernetes.podspec-volumes-emptydir || fail_test
     go_test_e2e -tags=e2e -timeout=15m -parallel=1 \
     ./test/e2e ./test/conformance/api/... ./test/conformance/runtime/... \
     -run "^(${test_name})$" \
@@ -259,8 +258,6 @@ function run_e2e_tests(){
     --https \
     --skip-cleanup-on-fail \
     --resolvabledomain || failed=$?
-    disable_feature_flags kubernetes.podspec-volumes-emptydir || fail_test
-
     return $failed
   fi
 
@@ -272,7 +269,6 @@ function run_e2e_tests(){
     parallel=2
   fi
 
-  enable_feature_flags kubernetes.podspec-volumes-emptydir || fail_test
   go_test_e2e -tags=e2e -timeout=30m -parallel=$parallel \
     ./test/e2e ./test/conformance/api/... ./test/conformance/runtime/... \
     --kubeconfig "$KUBECONFIG" \
@@ -283,7 +279,6 @@ function run_e2e_tests(){
     --https \
     --skip-cleanup-on-fail \
     --resolvabledomain || failed=1
-  disable_feature_flags kubernetes.podspec-volumes-emptydir || fail_test
 
  enable_feature_flags tag-header-based-routing || fail_test
  go_test_e2e -timeout=2m ./test/e2e/tagheader \
@@ -325,14 +320,14 @@ function run_e2e_tests(){
     --resolvabledomain || failed=1
 
   # Run init-containers test
-  enable_feature_flags kubernetes.podspec-volumes-emptydir kubernetes.podspec-init-containers || fail_test
+  enable_feature_flags kubernetes.podspec-init-containers || fail_test
   go_test_e2e -timeout=2m ./test/e2e/initcontainers \
     --kubeconfig "$KUBECONFIG" \
     --imagetemplate "$TEST_IMAGE_TEMPLATE" \
     --https \
     --skip-cleanup-on-fail \
     --resolvabledomain || failed=1
-  disable_feature_flags kubernetes.podspec-volumes-emptydir kubernetes.podspec-init-containers || fail_test
+  disable_feature_flags kubernetes.podspec-init-containers || fail_test
 
   # Run PVC test
   enable_feature_flags kubernetes.podspec-persistent-volume-claim kubernetes.podspec-persistent-volume-write kubernetes.podspec-securitycontext || fail_test


### PR DESCRIPTION
**What this PR does / why we need it**:

As https://github.com/openshift-knative/serving/commit/6e597fa7fd731ec7c655566bfb3bae9caa1fc0d4 changed the default, we don't need this anymore.

**Does this PR needs for other branches**:

/cherry-pick release-v1.10
/cherry-pick release-v1.9

**Does this PR (patch) needs to update/drop in the future?**:

NONE