### PR TITLE
Use Kourier v1.11 instead of v1.10 for release-next

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -149,6 +149,12 @@ function install_serverless(){
   export GOPATH=/tmp/go
   export ON_CLUSTER_BUILDS=true
   export DOCKER_REPO_OVERRIDE=image-registry.openshift-image-registry.svc:5000/openshift-marketplace
+
+  # TODO: Remove this workaround once SO started using kourier v1.11.
+  # This workaround is necessary as release-next has serving/pull/14074, which requires net-kourier/pull/1058.
+  sed "s/kourier: knative-v1.10/kourier: knative-v1.11/" -i olm-catalog/serverless-operator/project.yaml
+  sed "s/net_kourier_artifacts_branch: release-v1.10/net_kourier_artifacts_branch: release-v1.11/" -i olm-catalog/serverless-operator/project.yaml
+
   OPENSHIFT_CI="true" make generated-files images install-serving || return $?
 
   # Create a secret for https test.


### PR DESCRIPTION
**What this PR does / why we need it**:

This change https://github.com/knative/serving/pull/14074 requires Kourier 1.11 which includes https://github.com/knative-extensions/net-kourier/pull/1058.
However currently release-next branch uses Kourier v1.10 so we need to tweak until SO repo has kourier v1.11.

**Which issue(s) this PR fixes**:

NONE as only CI release-next issue.

**Does this PR needs for other branches**:

No, as release-1.11 branch does not have https://github.com/knative/serving/pull/14074.

**Does this PR (patch) needs to update/drop in the future?**:

JIRA: https://issues.redhat.com/browse/SRVKS-1112
