### PR TITLE
install helm in build-image

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -7,6 +7,9 @@ ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/
 
 RUN yum install -y kubectl httpd-tools
 
+# Serverless-Operator `make generated-files` needs helm
+RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
 RUN GOFLAGS='' go install github.com/mikefarah/yq/v3@latest
 RUN GOFLAGS='' go install knative.dev/test-infra/tools/kntest/cmd/kntest@latest
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Install helm in build-image as Serverless-Operator `make generated-files` needs helm
- Fixes https://github.com/openshift-knative/serving/pull/421

**Does this PR needs for other branches**:
NONE

**Does this PR (patch) needs to update/drop in the future?**:
NO

