### PR TITLE
[release-v1.11] Do not skip TestTargetBurstCapacity when `dataplane-trust` is not specified

### DIFF
--- a/test/e2e/autoscale_test.go
+++ b/test/e2e/autoscale_test.go
@@ -173,9 +173,11 @@ func TestTargetBurstCapacity(t *testing.T) {
 	if err != nil {
 		t.Fatal("Fail to get ConfigMap config-network:", err)
 	}
-	if !strings.EqualFold(cm.Data[netcfg.DataplaneTrustKey], string(netcfg.TrustDisabled)) {
-		// TODO: Remove this when https://github.com/knative/serving/issues/12797 was done.
-		t.Skip("Skipping TestTargetBurstCapacity as activator-ca is specified. See issue/12797.")
+
+	// TODO: Remove this when "activator always stay in path" is eliminated.
+	dataplaneTrustMode := cm.Data[netcfg.DataplaneTrustKey]
+	if (dataplaneTrustMode != "" && !strings.EqualFold(dataplaneTrustMode, string(netcfg.TrustDisabled))) || strings.EqualFold(cm.Data[netcfg.InternalEncryptionKey], "true") {
+		t.Skip("Skipping TestTargetBurstCapacity as activator always stay in path.")
 	}
 
 	cfg, err := autoscalerCM(ctx.clients)


### PR DESCRIPTION
**What this PR does / why we need it**:

This patch cherry-pick 43f7526 
`TestTargetBurstCapacity` is skipped on v1.11 - see https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/periodic-ci-openshift-knative-serving-release-v1.11-413-test-e2e-aws-ocp-413-continuous

**Which issue(s) this PR fixes**:

NONE

**Does this PR needs for other branches**:

NONE

**Does this PR (patch) needs to update/drop in the future?**:

No, upstream main branch fixed it.