### PR TITLE
[SRVKS-1111][release-v1.11] Support conformance test with cgroup v2 (#14297)

### DIFF
--- a/test/conformance/runtime/cgroup_test.go
+++ b/test/conformance/runtime/cgroup_test.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"knative.dev/serving/test"
+	"knative.dev/serving/test/types"
 
 	. "knative.dev/serving/pkg/testing/v1"
 )
@@ -41,6 +42,15 @@ func toMilliValue(value float64) string {
 	return fmt.Sprintf("%dm", int(value*1000))
 }
 
+func isCgroupsV2(mounts []*types.Mount) (bool, error) {
+	for _, mount := range mounts {
+		if mount.Path == "/sys/fs/cgroup" {
+			return mount.Type == "cgroup2", nil
+		}
+	}
+	return false, fmt.Errorf("Failed to find cgroup mount on /sys/fs/cgroup")
+}
+
 // TestMustHaveCgroupConfigured verifies that the Linux cgroups are configured based on the specified
 // resource limits and requests as delared by "MUST" in the runtime-contract.
 func TestMustHaveCgroupConfigured(t *testing.T) {
@@ -49,22 +59,37 @@ func TestMustHaveCgroupConfigured(t *testing.T) {
 
 	resources := createResources()
 
+	_, ri, err := fetchRuntimeInfo(t, clients, WithResourceRequirements(resources))
+	if err != nil {
+		t.Fatal("Error fetching runtime info:", err)
+	}
+
 	// Cgroup settings are based on the CPU and Memory Limits as well as CPU Requests
 	// https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
 	//
 	// It's important to make sure that the memory limit is divisible by common page
 	// size (4k, 8k, 16k, 64k) as some environments apply rounding to the closest page
 	// size multiple, see https://github.com/kubernetes/kubernetes/issues/82230.
-	expectedCgroups := map[string]int{
+	var expectedCgroupsV1 = map[string]int{
 		"/sys/fs/cgroup/memory/memory.limit_in_bytes": int(resources.Limits.Memory().Value()) &^ 4095, // floor() to 4K pages
 		"/sys/fs/cgroup/cpu/cpu.shares":               int(resources.Requests.Cpu().MilliValue()) * 1024 / 1000}
 
-	_, ri, err := fetchRuntimeInfo(t, clients, WithResourceRequirements(resources))
-	if err != nil {
-		t.Fatal("Error fetching runtime info:", err)
-	}
+	var expectedCgroupsV2 = map[string]int{
+		"/sys/fs/cgroup/memory.max": int(resources.Limits.Memory().Value()) &^ 4095, // floor() to 4K pages
+		"/sys/fs/cgroup/cpu.weight": int(resources.Requests.Cpu().MilliValue()) * 1024 / 1000,
+		"/sys/fs/cgroup/cpu.max":    int(resources.Limits.Cpu().MilliValue())}
 
 	cgroups := ri.Host.Cgroups
+	cgroupV2, err := isCgroupsV2(ri.Host.Mounts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedCgroups := expectedCgroupsV1
+	if cgroupV2 {
+		t.Logf("using cgroupv2")
+		expectedCgroups = expectedCgroupsV2
+	}
 
 	// These are used to check the ratio of 'period' to 'quota'. It needs to
 	// be equal to the 'cpuLimit (limit = period / quota)
@@ -96,20 +121,21 @@ func TestMustHaveCgroupConfigured(t *testing.T) {
 		}
 	}
 
-	expectedCPULimit := int(resources.Limits.Cpu().MilliValue())
-	if period == nil {
-		t.Error("Can't find the 'cpu.cfs_period_us' from cgroups")
-	} else if quota == nil {
-		t.Error("Can't find the 'cpu.cfs_quota_us' from cgroups")
-	} else {
-		// CustomCpuLimits of a core e.g. 125m means 12,5% of a single CPU, 2 or 2000m means 200% of a single CPU
-		milliCPU := (1000 * (*quota)) / (*period)
-		if milliCPU != expectedCPULimit {
-			t.Errorf("MilliCPU (%v) is wrong should be %v. Period: %v Quota: %v",
-				milliCPU, expectedCPULimit, period, quota)
+	if !cgroupV2 {
+		expectedCPULimit := int(resources.Limits.Cpu().MilliValue())
+		if period == nil {
+			t.Error("Can't find the 'cpu.cfs_period_us' from cgroups")
+		} else if quota == nil {
+			t.Error("Can't find the 'cpu.cfs_quota_us' from cgroups")
+		} else {
+			// CustomCpuLimits of a core e.g. 125m means 12,5% of a single CPU, 2 or 2000m means 200% of a single CPU
+			milliCPU := (1000 * (*quota)) / (*period)
+			if milliCPU != expectedCPULimit {
+				t.Errorf("MilliCPU (%v) is wrong should be %v. Period: %v Quota: %v",
+					milliCPU, expectedCPULimit, period, quota)
+			}
 		}
 	}
-
 }
 
 // TestShouldHaveCgroupReadOnly verifies that the Linux cgroups are mounted read-only within the

--- a/test/test_images/runtime/handlers/runtime.go
+++ b/test/test_images/runtime/handlers/runtime.go
@@ -48,7 +48,7 @@ func runtimeHandler(w http.ResponseWriter, r *http.Request) {
 		Host: &types.HostInfo{EnvVars: env(),
 			Files:      fileInfo(filePaths...),
 			FileAccess: fileAccessAttempt(excludeFilePaths(filePaths, fileAccessExclusions)...),
-			Cgroups:    cgroups(cgroupPaths...),
+			Cgroups:    cgroups(cgroupPaths()...),
 			Mounts:     mounts(),
 			Stdin:      stdin(),
 			User:       userInfo(),


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR cherry-pick d39a379708e208fbba1dab93874170c1bf3d7c37.
OCP 4.11 uses cgroup v2 so we need this change or skip the test as https://github.com/openshift-knative/serverless-operator/pull/2210

**Which issue(s) this PR fixes**:

https://issues.redhat.com/browse/SRVKS-1111

**Does this PR needs for other branches**:

/cherry-pick release-v1.10

**Does this PR (patch) needs to update/drop in the future?**:

No.