### PR TITLE
[TEST] remove sec profile from queue

### DIFF
--- a/pkg/reconciler/revision/resources/queue.go
+++ b/pkg/reconciler/revision/resources/queue.go
@@ -86,9 +86,6 @@ var (
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},
 		},
-		SeccompProfile: &corev1.SeccompProfile{
-			Type: corev1.SeccompProfileTypeRuntimeDefault,
-		},
 	}
 )
 


### PR DESCRIPTION
TEST-ONLY for fixing https://github.com/openshift-knative/serving/pull/455. OCP injects the right profile when it is appropriate so we leave it empty.