### PR TITLE
Increase progressDeadline for PVC tests to 600 seconds

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -312,9 +312,11 @@ function run_e2e_tests(){
 
   # Run PVC test
   enable_feature_flags kubernetes.podspec-persistent-volume-claim kubernetes.podspec-persistent-volume-write kubernetes.podspec-securitycontext || fail_test
-  go_test_e2e -timeout=5m ./test/e2e/pvc \
+  configure_cm deployment progressDeadline:600s || fail_test
+  go_test_e2e -timeout=15m ./test/e2e/pvc \
     --imagetemplate "$TEST_IMAGE_TEMPLATE" \
     ${OPENSHIFT_TEST_OPTIONS} || failed=1
+  configure_cm deployment progressDeadline:120s || fail_test
   disable_feature_flags kubernetes.podspec-persistent-volume-claim kubernetes.podspec-persistent-volume-write kubernetes.podspec-securitycontext || fail_test
 
   # Run the helloworld test with an image pulled into the internal registry.


### PR DESCRIPTION
Provisioning a volume might take longer than default 120s.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

JIRA: https://issues.redhat.com/browse/SRVCOM-2845

**Does this PR needs for other branches**:

<!--
If no, just write "NONE".
If yes, add cherry-pick label:

/cherry-pick release-vX.Y
-->

**Does this PR (patch) needs to update/drop in the future?**:

<!--
If no, just write "NONE".
If yes, please open the JIRA and link here:
-->

JIRA:
