### PR TITLE
Bring back "[Main] images and Makefile target"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,14 @@ test-e2e:
 	./openshift/e2e-tests.sh
 .PHONY: test-e2e
 
+perf-tests:
+	export ES_DEVELOPMENT=true && \
+	export ES_HOST_PORT=search-perfscale-dev-chmf5l4sh66lvxbnadi4bznl3a.us-west-2.es.amazonaws.com && \
+	export USE_OPEN_SEARCH=true && \
+	export SYSTEM_NAMESPACE=knative-serving && \
+	./openshift/perf-tests.sh
+.PHONY: perf-tests
+
 test-e2e-tls:
 	ENABLE_INTERNAL_TLS="true" ./openshift/e2e-tests.sh
 .PHONY: test-e2e-tls

--- a/openshift/ci-operator/knative-perf-images/dataplane-probe/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/dataplane-probe/Dockerfile
@@ -1,0 +1,13 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+
+COPY . .
+
+RUN ./openshift/in-docker-patch.sh
+RUN make perf-install
+
+FROM openshift/origin-base
+USER 65532
+
+COPY --from=builder /go/bin/dataplane-probe /ko-app/dataplane-probe
+ENTRYPOINT ["/ko-app/dataplane-probe"]

--- a/openshift/ci-operator/knative-perf-images/load-test/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/load-test/Dockerfile
@@ -1,0 +1,13 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+
+COPY . .
+
+RUN ./openshift/in-docker-patch.sh
+RUN make perf-install
+
+FROM openshift/origin-base
+USER 65532
+
+COPY --from=builder /go/bin/load-test /ko-app/load-test
+ENTRYPOINT ["/ko-app/load-test"]

--- a/openshift/ci-operator/knative-perf-images/real-traffic-test/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/real-traffic-test/Dockerfile
@@ -1,0 +1,13 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+
+COPY . .
+
+RUN ./openshift/in-docker-patch.sh
+RUN make perf-install
+
+FROM openshift/origin-base
+USER 65532
+
+COPY --from=builder /go/bin/real-traffic-test /ko-app/real-traffic-test
+ENTRYPOINT ["/ko-app/real-traffic-test"]

--- a/openshift/ci-operator/knative-perf-images/reconciliation-delay/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/reconciliation-delay/Dockerfile
@@ -1,0 +1,13 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+
+COPY . .
+
+RUN ./openshift/in-docker-patch.sh
+RUN make perf-install
+
+FROM openshift/origin-base
+USER 65532
+
+COPY --from=builder /go/bin/reconciliation-delay /ko-app/reconciliation-delay
+ENTRYPOINT ["/ko-app/reconciliation-delay"]

--- a/openshift/ci-operator/knative-perf-images/rollout-probe/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/rollout-probe/Dockerfile
@@ -1,0 +1,13 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+
+COPY . .
+
+RUN ./openshift/in-docker-patch.sh
+RUN make perf-install
+
+FROM openshift/origin-base
+USER 65532
+
+COPY --from=builder /go/bin/rollout-probe /ko-app/rollout-probe
+ENTRYPOINT ["/ko-app/rollout-probe"]

--- a/openshift/ci-operator/knative-perf-images/scale-from-zero/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/scale-from-zero/Dockerfile
@@ -1,0 +1,13 @@
+# Do not edit! This file was generated via Makefile
+FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+
+COPY . .
+
+RUN ./openshift/in-docker-patch.sh
+RUN make perf-install
+
+FROM openshift/origin-base
+USER 65532
+
+COPY --from=builder /go/bin/scale-from-zero /ko-app/scale-from-zero
+ENTRYPOINT ["/ko-app/scale-from-zero"]

--- a/openshift/performance/patches/perf.patch
+++ b/openshift/performance/patches/perf.patch
@@ -1,5 +1,5 @@
 diff --git a/Makefile b/Makefile
-index 9e3172f82..4da396560 100644
+index 21872e521..45b7b7e22 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -6,6 +6,7 @@ CORE_IMAGES=./cmd/activator ./cmd/autoscaler ./cmd/autoscaler-hpa ./cmd/controll
@@ -10,7 +10,7 @@ index 9e3172f82..4da396560 100644
  BRANCH=
  TEST=
  IMAGE=
-@@ -26,10 +27,20 @@ test-install:
+@@ -26,6 +27,12 @@ test-install:
  	done
  .PHONY: test-install
 
@@ -23,15 +23,7 @@ index 9e3172f82..4da396560 100644
  test-e2e:
  	./openshift/e2e-tests.sh
  .PHONY: test-e2e
-
-+perf-tests:
-+	./openshift/perf-tests.sh
-+.PHONY: perf-tests
-+
- test-e2e-tls:
- 	ENABLE_INTERNAL_TLS="true" ./openshift/e2e-tests.sh
- .PHONY: test-e2e-tls
-@@ -60,8 +71,9 @@ test-e2e-local:
+@@ -68,8 +75,9 @@ test-e2e-local:
 
  # Generate Dockerfiles for core and test images used by ci-operator. The files need to be committed manually.
  generate-dockerfiles:


### PR DESCRIPTION
This reverts commit cfaa224a8f6cb03715dc41b8265f19064f680569.

**What this PR does / why we need it**:

- See https://github.com/openshift-knative/hack/pull/94 for more.
- Reverts #520 
