### PR TITLE
[MAIN] Move to Golang version 1.21

### DIFF
--- a/.github/workflows/multiarch-build.yaml
+++ b/.github/workflows/multiarch-build.yaml
@@ -8,3 +8,5 @@ jobs:
   multiarch-build:
     uses: openshift-knative/hack/.github/workflows/multiarch-build.yaml@main
     secrets: inherit
+    with:
+      goversion: '1.21.x'

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19.x
+          go-version: 1.21.x
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -48,10 +48,10 @@ jobs:
     env:
       GOPATH: ${{ github.workspace }}
     steps:
-      - name: Set up Go 1.19.x
+      - name: Set up Go 1.21.x
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19.x
+          go-version: 1.21.x
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/vulncheck.yaml
+++ b/.github/workflows/vulncheck.yaml
@@ -19,10 +19,10 @@ jobs:
     env:
       GOPATH: ${{ github.workspace }}
     steps:
-      - name: Set up Go 1.18.x
-        uses: actions/setup-go@v2
+      - name: Set up Go 1.21.x
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.18.x
+          go-version: 1.21.x
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/openshift/ci-operator/Dockerfile.in
+++ b/openshift/ci-operator/Dockerfile.in
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 RUN make install test-install

--- a/openshift/ci-operator/Dockerfile_with_kodata.in
+++ b/openshift/ci-operator/Dockerfile_with_kodata.in
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 RUN make install test-install

--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to bootstrap build and test in openshift-ci
 
-FROM registry.ci.openshift.org/openshift/release:golang-1.19
+FROM registry.ci.openshift.org/openshift/release:golang-1.21
 
 # Add kubernetes repository
 ADD openshift/ci-operator/build-image/kubernetes.repo /etc/yum.repos.d/

--- a/openshift/ci-operator/knative-perf-images/dataplane-probe/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/dataplane-probe/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-perf-images/load-test/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/load-test/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-perf-images/real-traffic-test/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/real-traffic-test/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-perf-images/reconciliation-delay/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/reconciliation-delay/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-perf-images/rollout-probe/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/rollout-probe/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 

--- a/openshift/ci-operator/knative-perf-images/scale-from-zero/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/scale-from-zero/Dockerfile
@@ -1,5 +1,5 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 

--- a/openshift/performance/patches/perf.patch
+++ b/openshift/performance/patches/perf.patch
@@ -40,7 +40,7 @@ index 32b94bfb1..ce192d43d 100644
 --- a/openshift/ci-operator/Dockerfile.in
 +++ b/openshift/ci-operator/Dockerfile.in
 @@ -2,7 +2,7 @@
- FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+ FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
  COPY . .
 -RUN make install test-install
@@ -53,7 +53,7 @@ index 00de72095..0422ce541 100644
 --- a/openshift/ci-operator/Dockerfile_with_kodata.in
 +++ b/openshift/ci-operator/Dockerfile_with_kodata.in
 @@ -2,7 +2,7 @@
- FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+ FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
  COPY . .
 -RUN make install test-install


### PR DESCRIPTION
**What this PR does / why we need it**:

- See comment: https://github.com/openshift-knative/serving/pull/545#issuecomment-1827650117.
- Main upstream has moved to 1.21 and we need the same downstream for release-next and nightly jobs.



