### PR TITLE
Revert https://github.com/openshift-knative/serving/pull/413

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -142,12 +142,6 @@ function install_serverless(){
   export GOPATH=/tmp/go
   export ON_CLUSTER_BUILDS=true
   export DOCKER_REPO_OVERRIDE=image-registry.openshift-image-registry.svc:5000/openshift-marketplace
-
-  # TODO: Remove this workaround once SO started using kourier v1.11.
-  # This workaround is necessary as release-next has serving/pull/14074, which requires net-kourier/pull/1058.
-  sed "s/kourier: knative-v1.10/kourier: knative-v1.11/" -i olm-catalog/serverless-operator/project.yaml
-  sed "s/net_kourier_artifacts_branch: release-v1.10/net_kourier_artifacts_branch: release-v1.11/" -i olm-catalog/serverless-operator/project.yaml
-
   OPENSHIFT_CI="true" make generated-files images install-serving || return $?
 
   # Create a secret for https test.


### PR DESCRIPTION
**What this PR does / why we need it**:
- Reverts https://github.com/openshift-knative/serving/pull/413 as S-O uses net-kourier 1.11

**Which issue(s) this PR fixes**:

JIRA: https://issues.redhat.com/browse/SRVKS-1112

**Does this PR needs for other branches**:
NONE

**Does this PR (patch) needs to update/drop in the future?**:

NONE 

