### PR TITLE
[RELEASE-1.11] Use ubi8/ubi-minimal as base and re-generate CI images

### DIFF
--- a/openshift/ci-operator/Dockerfile.in
+++ b/openshift/ci-operator/Dockerfile.in
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/${bin} /ko-app/${bin}

--- a/openshift/ci-operator/Dockerfile_with_kodata.in
+++ b/openshift/ci-operator/Dockerfile_with_kodata.in
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY ${kodata_path} /var/run/ko

--- a/openshift/ci-operator/knative-images/activator/Dockerfile
+++ b/openshift/ci-operator/knative-images/activator/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY ./cmd/activator/kodata /var/run/ko

--- a/openshift/ci-operator/knative-images/autoscaler-hpa/Dockerfile
+++ b/openshift/ci-operator/knative-images/autoscaler-hpa/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY ./cmd/autoscaler-hpa/kodata /var/run/ko

--- a/openshift/ci-operator/knative-images/autoscaler/Dockerfile
+++ b/openshift/ci-operator/knative-images/autoscaler/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY ./cmd/autoscaler/kodata /var/run/ko

--- a/openshift/ci-operator/knative-images/controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/controller/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY ./cmd/controller/kodata /var/run/ko

--- a/openshift/ci-operator/knative-images/migrate/Dockerfile
+++ b/openshift/ci-operator/knative-images/migrate/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/migrate /ko-app/migrate

--- a/openshift/ci-operator/knative-images/queue/Dockerfile
+++ b/openshift/ci-operator/knative-images/queue/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY ./cmd/queue/kodata /var/run/ko

--- a/openshift/ci-operator/knative-images/webhook/Dockerfile
+++ b/openshift/ci-operator/knative-images/webhook/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY ./cmd/webhook/kodata /var/run/ko

--- a/openshift/ci-operator/knative-perf-images/dataplane-probe/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/dataplane-probe/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN ./openshift/in-docker-patch.sh
 RUN make perf-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/dataplane-probe /ko-app/dataplane-probe

--- a/openshift/ci-operator/knative-perf-images/load-test/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/load-test/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN ./openshift/in-docker-patch.sh
 RUN make perf-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/load-test /ko-app/load-test

--- a/openshift/ci-operator/knative-perf-images/real-traffic-test/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/real-traffic-test/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN ./openshift/in-docker-patch.sh
 RUN make perf-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/real-traffic-test /ko-app/real-traffic-test

--- a/openshift/ci-operator/knative-perf-images/reconciliation-delay/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/reconciliation-delay/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN ./openshift/in-docker-patch.sh
 RUN make perf-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/reconciliation-delay /ko-app/reconciliation-delay

--- a/openshift/ci-operator/knative-perf-images/rollout-probe/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/rollout-probe/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN ./openshift/in-docker-patch.sh
 RUN make perf-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/rollout-probe /ko-app/rollout-probe

--- a/openshift/ci-operator/knative-perf-images/scale-from-zero/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/scale-from-zero/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN ./openshift/in-docker-patch.sh
 RUN make perf-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/scale-from-zero /ko-app/scale-from-zero

--- a/openshift/ci-operator/knative-test-images/autoscale/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/autoscale/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/autoscale /ko-app/autoscale

--- a/openshift/ci-operator/knative-test-images/failing/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/failing/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/failing /ko-app/failing

--- a/openshift/ci-operator/knative-test-images/grpc-ping/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/grpc-ping/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/grpc-ping /ko-app/grpc-ping

--- a/openshift/ci-operator/knative-test-images/hellohttp2/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/hellohttp2/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/hellohttp2 /ko-app/hellohttp2

--- a/openshift/ci-operator/knative-test-images/hellovolume/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/hellovolume/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/hellovolume /ko-app/hellovolume

--- a/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/helloworld /ko-app/helloworld

--- a/openshift/ci-operator/knative-test-images/httpproxy/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/httpproxy/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/httpproxy /ko-app/httpproxy

--- a/openshift/ci-operator/knative-test-images/pizzaplanetv1/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/pizzaplanetv1/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/pizzaplanetv1 /ko-app/pizzaplanetv1

--- a/openshift/ci-operator/knative-test-images/pizzaplanetv2/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/pizzaplanetv2/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/pizzaplanetv2 /ko-app/pizzaplanetv2

--- a/openshift/ci-operator/knative-test-images/readiness/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/readiness/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/readiness /ko-app/readiness

--- a/openshift/ci-operator/knative-test-images/runtime/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/runtime/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/runtime /ko-app/runtime

--- a/openshift/ci-operator/knative-test-images/servingcontainer/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/servingcontainer/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/servingcontainer /ko-app/servingcontainer

--- a/openshift/ci-operator/knative-test-images/sidecarcontainer/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/sidecarcontainer/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/sidecarcontainer /ko-app/sidecarcontainer

--- a/openshift/ci-operator/knative-test-images/singlethreaded/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/singlethreaded/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/singlethreaded /ko-app/singlethreaded

--- a/openshift/ci-operator/knative-test-images/slowstart/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/slowstart/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/slowstart /ko-app/slowstart

--- a/openshift/ci-operator/knative-test-images/timeout/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/timeout/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/timeout /ko-app/timeout

--- a/openshift/ci-operator/knative-test-images/volumes/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/volumes/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/volumes /ko-app/volumes

--- a/openshift/ci-operator/knative-test-images/wsserver/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/wsserver/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/wsserver /ko-app/wsserver

--- a/openshift/performance/patches/perf.patch
+++ b/openshift/performance/patches/perf.patch
@@ -50,7 +50,7 @@ index 13464e22b..5cc2e3fbe 100644
  	_ "k8s.io/code-generator/cmd/deepcopy-gen"
  	_ "k8s.io/code-generator/cmd/defaulter-gen"
 diff --git a/openshift/ci-operator/Dockerfile.in b/openshift/ci-operator/Dockerfile.in
-index 32b94bfb1..ce192d43d 100644
+index 1c31865cc..7bd47161b 100644
 --- a/openshift/ci-operator/Dockerfile.in
 +++ b/openshift/ci-operator/Dockerfile.in
 @@ -2,7 +2,7 @@
@@ -60,10 +60,10 @@ index 32b94bfb1..ce192d43d 100644
 -RUN make install test-install
 +RUN make install test-install perf-install
  
- FROM openshift/origin-base
+ FROM registry.access.redhat.com/ubi8/ubi-minimal
  USER 65532
 diff --git a/openshift/ci-operator/Dockerfile_with_kodata.in b/openshift/ci-operator/Dockerfile_with_kodata.in
-index 00de72095..0422ce541 100644
+index 9d84e5ecc..572d91c25 100644
 --- a/openshift/ci-operator/Dockerfile_with_kodata.in
 +++ b/openshift/ci-operator/Dockerfile_with_kodata.in
 @@ -2,7 +2,7 @@
@@ -73,7 +73,7 @@ index 00de72095..0422ce541 100644
 -RUN make install test-install
 +RUN make install test-install perf-install
  
- FROM openshift/origin-base
+ FROM registry.access.redhat.com/ubi8/ubi-minimal
  USER 65532
 diff --git a/test/performance/profiling.md b/test/performance/PROFILING.md
 similarity index 100%


### PR DESCRIPTION
**What this PR does / why we need it**:

Similar to https://github.com/openshift-knative/serverless-operator/pull/2452
ubi-minimal is much smaller in size, it's multiarch, and it's used by product images built in Brew anyway. CI can use the same.

**Which issue(s) this PR fixes**:

Related to https://issues.redhat.com/browse/SRVKS-1024 but doesn't fully fix it.

**Does this PR needs for other branches**:

release-v1.12 and main

<!--
If no, just write "NONE".
If yes, add cherry-pick label:

/cherry-pick release-vX.Y
-->

**Does this PR (patch) needs to update/drop in the future?**:

<!--
If no, just write "NONE".
If yes, please open the JIRA and link here:
-->

JIRA:
