### PR TITLE
[release-v1.12] Use ubi8/ubi-minimal as base and re-generate CI images

### DIFF
--- a/openshift/ci-operator/Dockerfile.in
+++ b/openshift/ci-operator/Dockerfile.in
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/${bin} /ko-app/${bin}

--- a/openshift/ci-operator/Dockerfile_with_kodata.in
+++ b/openshift/ci-operator/Dockerfile_with_kodata.in
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY ${kodata_path} /var/run/ko

--- a/openshift/ci-operator/knative-images/activator/Dockerfile
+++ b/openshift/ci-operator/knative-images/activator/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY ./cmd/activator/kodata /var/run/ko

--- a/openshift/ci-operator/knative-images/autoscaler-hpa/Dockerfile
+++ b/openshift/ci-operator/knative-images/autoscaler-hpa/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY ./cmd/autoscaler-hpa/kodata /var/run/ko

--- a/openshift/ci-operator/knative-images/autoscaler/Dockerfile
+++ b/openshift/ci-operator/knative-images/autoscaler/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY ./cmd/autoscaler/kodata /var/run/ko

--- a/openshift/ci-operator/knative-images/controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/controller/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY ./cmd/controller/kodata /var/run/ko

--- a/openshift/ci-operator/knative-images/migrate/Dockerfile
+++ b/openshift/ci-operator/knative-images/migrate/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/migrate /ko-app/migrate

--- a/openshift/ci-operator/knative-images/queue/Dockerfile
+++ b/openshift/ci-operator/knative-images/queue/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY ./cmd/queue/kodata /var/run/ko

--- a/openshift/ci-operator/knative-images/webhook/Dockerfile
+++ b/openshift/ci-operator/knative-images/webhook/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY ./cmd/webhook/kodata /var/run/ko

--- a/openshift/ci-operator/knative-perf-images/dataplane-probe/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/dataplane-probe/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN ./openshift/in-docker-patch.sh
 RUN make perf-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/dataplane-probe /ko-app/dataplane-probe

--- a/openshift/ci-operator/knative-perf-images/load-test/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/load-test/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN ./openshift/in-docker-patch.sh
 RUN make perf-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/load-test /ko-app/load-test

--- a/openshift/ci-operator/knative-perf-images/real-traffic-test/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/real-traffic-test/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN ./openshift/in-docker-patch.sh
 RUN make perf-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/real-traffic-test /ko-app/real-traffic-test

--- a/openshift/ci-operator/knative-perf-images/reconciliation-delay/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/reconciliation-delay/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN ./openshift/in-docker-patch.sh
 RUN make perf-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/reconciliation-delay /ko-app/reconciliation-delay

--- a/openshift/ci-operator/knative-perf-images/rollout-probe/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/rollout-probe/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN ./openshift/in-docker-patch.sh
 RUN make perf-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/rollout-probe /ko-app/rollout-probe

--- a/openshift/ci-operator/knative-perf-images/scale-from-zero/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/scale-from-zero/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN ./openshift/in-docker-patch.sh
 RUN make perf-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/scale-from-zero /ko-app/scale-from-zero

--- a/openshift/ci-operator/knative-test-images/autoscale/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/autoscale/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/autoscale /ko-app/autoscale

--- a/openshift/ci-operator/knative-test-images/failing/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/failing/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/failing /ko-app/failing

--- a/openshift/ci-operator/knative-test-images/grpc-ping/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/grpc-ping/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/grpc-ping /ko-app/grpc-ping

--- a/openshift/ci-operator/knative-test-images/hellohttp2/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/hellohttp2/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/hellohttp2 /ko-app/hellohttp2

--- a/openshift/ci-operator/knative-test-images/hellovolume/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/hellovolume/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/hellovolume /ko-app/hellovolume

--- a/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/helloworld /ko-app/helloworld

--- a/openshift/ci-operator/knative-test-images/httpproxy/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/httpproxy/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/httpproxy /ko-app/httpproxy

--- a/openshift/ci-operator/knative-test-images/pizzaplanetv1/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/pizzaplanetv1/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/pizzaplanetv1 /ko-app/pizzaplanetv1

--- a/openshift/ci-operator/knative-test-images/pizzaplanetv2/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/pizzaplanetv2/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/pizzaplanetv2 /ko-app/pizzaplanetv2

--- a/openshift/ci-operator/knative-test-images/readiness/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/readiness/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/readiness /ko-app/readiness

--- a/openshift/ci-operator/knative-test-images/runtime/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/runtime/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/runtime /ko-app/runtime

--- a/openshift/ci-operator/knative-test-images/servingcontainer/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/servingcontainer/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/servingcontainer /ko-app/servingcontainer

--- a/openshift/ci-operator/knative-test-images/sidecarcontainer/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/sidecarcontainer/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/sidecarcontainer /ko-app/sidecarcontainer

--- a/openshift/ci-operator/knative-test-images/singlethreaded/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/singlethreaded/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/singlethreaded /ko-app/singlethreaded

--- a/openshift/ci-operator/knative-test-images/slowstart/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/slowstart/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/slowstart /ko-app/slowstart

--- a/openshift/ci-operator/knative-test-images/timeout/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/timeout/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/timeout /ko-app/timeout

--- a/openshift/ci-operator/knative-test-images/volumes/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/volumes/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/volumes /ko-app/volumes

--- a/openshift/ci-operator/knative-test-images/wsserver/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/wsserver/Dockerfile
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.19 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/wsserver /ko-app/wsserver

--- a/openshift/performance/patches/perf.patch
+++ b/openshift/performance/patches/perf.patch
@@ -46,7 +46,7 @@ index 32b94bfb1..ce192d43d 100644
 -RUN make install test-install
 +RUN make install test-install perf-install
 
- FROM openshift/origin-base
+ FROM registry.access.redhat.com/ubi8/ubi-minimal
  USER 65532
 diff --git a/openshift/ci-operator/Dockerfile_with_kodata.in b/openshift/ci-operator/Dockerfile_with_kodata.in
 index 00de72095..0422ce541 100644
@@ -59,7 +59,7 @@ index 00de72095..0422ce541 100644
 -RUN make install test-install
 +RUN make install test-install perf-install
 
- FROM openshift/origin-base
+ FROM registry.access.redhat.com/ubi8/ubi-minimal
  USER 65532
 diff --git a/test/performance/README.md b/test/performance/README.md
 index a4906039a..f17f7cffc 100644


### PR DESCRIPTION
**What this PR does / why we need it**:

Similar to https://github.com/openshift-knative/serverless-operator/pull/2452
ubi-minimal is much smaller in size, it's multiarch, and it's used by product images built in Brew anyway. CI can use the same.

**Which issue(s) this PR fixes**:

JIRA:

**Does this PR needs for other branches**:

<!--
If no, just write "NONE".
If yes, add cherry-pick label:

/cherry-pick release-vX.Y
-->

**Does this PR (patch) needs to update/drop in the future?**:

<!--
If no, just write "NONE".
If yes, please open the JIRA and link here:
-->

JIRA:
