### PR TITLE
[main] Use ubi8/ubi-minimal as base

### DIFF
--- a/openshift/ci-operator/Dockerfile.in
+++ b/openshift/ci-operator/Dockerfile.in
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/${bin} /ko-app/${bin}

--- a/openshift/ci-operator/Dockerfile_with_kodata.in
+++ b/openshift/ci-operator/Dockerfile_with_kodata.in
@@ -4,7 +4,7 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
 COPY . .
 RUN make install test-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY ${kodata_path} /var/run/ko

--- a/openshift/ci-operator/knative-perf-images/dataplane-probe/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/dataplane-probe/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN ./openshift/in-docker-patch.sh
 RUN make perf-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/dataplane-probe /ko-app/dataplane-probe

--- a/openshift/ci-operator/knative-perf-images/load-test/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/load-test/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN ./openshift/in-docker-patch.sh
 RUN make perf-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/load-test /ko-app/load-test

--- a/openshift/ci-operator/knative-perf-images/real-traffic-test/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/real-traffic-test/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN ./openshift/in-docker-patch.sh
 RUN make perf-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/real-traffic-test /ko-app/real-traffic-test

--- a/openshift/ci-operator/knative-perf-images/reconciliation-delay/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/reconciliation-delay/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN ./openshift/in-docker-patch.sh
 RUN make perf-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/reconciliation-delay /ko-app/reconciliation-delay

--- a/openshift/ci-operator/knative-perf-images/rollout-probe/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/rollout-probe/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN ./openshift/in-docker-patch.sh
 RUN make perf-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/rollout-probe /ko-app/rollout-probe

--- a/openshift/ci-operator/knative-perf-images/scale-from-zero/Dockerfile
+++ b/openshift/ci-operator/knative-perf-images/scale-from-zero/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN ./openshift/in-docker-patch.sh
 RUN make perf-install
 
-FROM openshift/origin-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/scale-from-zero /ko-app/scale-from-zero


### PR DESCRIPTION
**What this PR does / why we need it**:

Similar to https://github.com/openshift-knative/serverless-operator/pull/2452
ubi-minimal is much smaller in size, it's multiarch, and it's used by product images built in Brew anyway. CI can use the same.

**Which issue(s) this PR fixes**:

JIRA:

**Does this PR needs for other branches**:

<!--
If no, just write "NONE".
If yes, add cherry-pick label:

/cherry-pick release-vX.Y
-->

**Does this PR (patch) needs to update/drop in the future?**:

<!--
If no, just write "NONE".
If yes, please open the JIRA and link here:
-->

JIRA:
