### PR TITLE
[MAIN] Disable internal encryption

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -142,6 +142,8 @@ function install_serverless(){
   export GOPATH=/tmp/go
   export ON_CLUSTER_BUILDS=true
   export DOCKER_REPO_OVERRIDE=image-registry.openshift-image-registry.svc:5000/openshift-marketplace
+  #TODO: enable back when we have the feature ready again downstream
+  sed -i 's/internal-encryption: "true"/internal-encryption: "false"/g' ./test/v1beta1/resources/operator.knative.dev_v1beta1_knativeserving_cr.yaml
   OPENSHIFT_CI="true" make generated-files images install-serving || return $?
 
   # Create a secret for https test.


### PR DESCRIPTION
**What this PR does / why we need it**
- Right now internal encryption is enabled by default at the S-O a bit too early. The feature has changed in .13 and main
and still is wip so we need to disable to avoid breaking runs without tls. See https://github.com/openshift-knative/serving/pull/606 for more.
- We need the same for 1.13.