### PR TITLE
Align go version with https://github.com/openshift-knative/hack/pull/103

### DIFF
--- a/.github/workflows/multiarch-build.yaml
+++ b/.github/workflows/multiarch-build.yaml
@@ -8,5 +8,3 @@ jobs:
   multiarch-build:
     uses: openshift-knative/hack/.github/workflows/multiarch-build.yaml@main
     secrets: inherit
-    with:
-      goversion: '1.21.x'

--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   sync-upstream:
     if: github.event.created || github.event_name == 'workflow_dispatch'
-    name:
+    name: Sync with upstream
     runs-on: ubuntu-latest
     env:
       GOPATH: ${{ github.workspace }}

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -15,16 +15,16 @@ jobs:
     env:
       GOPATH: ${{ github.workspace }}
     steps:
-      - name: Setup Golang
-        uses: actions/setup-go@v4
-        with:
-          go-version: 1.21.x
-
       - name: Checkout
         uses: actions/checkout@v3
         with:
           path: ./src/github.com/${{ github.repository }}
           fetch-depth: 0
+
+      - name: Setup Golang
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: ./src/github.com/${{ github.repository }}/go.mod
 
       - name: Regenerate all generated files
         working-directory: ./src/github.com/${{ github.repository }}
@@ -48,15 +48,15 @@ jobs:
     env:
       GOPATH: ${{ github.workspace }}
     steps:
-      - name: Set up Go 1.21.x
-        uses: actions/setup-go@v4
-        with:
-          go-version: 1.21.x
-
       - name: Checkout
         uses: actions/checkout@v2
         with:
           path: ./src/github.com/${{ github.repository }}
+
+      - name: Setup Golang
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: ./src/github.com/${{ github.repository }}/go.mod
 
       - name: Install Tools
         working-directory: ./src/github.com/${{ github.repository }}

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -53,11 +53,6 @@ jobs:
         with:
           path: ./src/github.com/${{ github.repository }}
 
-      - name: Setup Golang
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: ./src/github.com/${{ github.repository }}/go.mod
-
       - name: Install Tools
         working-directory: ./src/github.com/${{ github.repository }}
         env:

--- a/.github/workflows/vulncheck.yaml
+++ b/.github/workflows/vulncheck.yaml
@@ -19,15 +19,16 @@ jobs:
     env:
       GOPATH: ${{ github.workspace }}
     steps:
-      - name: Set up Go 1.21.x
-        uses: actions/setup-go@v4
-        with:
-          go-version: 1.21.x
-
       - name: Checkout
         uses: actions/checkout@v2
         with:
           path: ./src/github.com/${{ github.repository }}
+
+      - name: Setup Golang
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: ./src/github.com/${{ github.repository }}/go.mod
+
 
       - name: Govulncheck scan
         working-directory: ./src/github.com/${{ github.repository }}

--- a/.github/workflows/vulncheck.yaml
+++ b/.github/workflows/vulncheck.yaml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   govulncheck:
+    if: github.base_ref != 'main'
     name: detect
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
**What this PR does / why we need it**:
- Align GH Action setup with https://github.com/openshift-knative/hack/pull/103
- Do not run golang checks on `main` as we do not have go code and `go.mod`

**Does this PR needs for other branches**:

/cherry-pick release-v1.12

/cherry-pick release-v1.13

**Does this PR (patch) needs to update/drop in the future?**:
No

/assign @skonto 