### PR TITLE
[main] add domain-mapping-test-certificate-uid-label.patch

### DIFF
--- a/openshift/patches/011-domain-mapping-test-certificate-uid-label.patch
+++ b/openshift/patches/011-domain-mapping-test-certificate-uid-label.patch
@@ -1,0 +1,23 @@
+diff --git a/test/e2e/domainmapping/domain_mapping_test.go b/test/e2e/domainmapping/domain_mapping_test.go
+index 4556b6f77..399c846ce 100644
+--- a/test/e2e/domainmapping/domain_mapping_test.go
++++ b/test/e2e/domainmapping/domain_mapping_test.go
+@@ -35,6 +35,8 @@ import (
+ 	"testing"
+ 	"time"
+ 
++	"knative.dev/networking/pkg/apis/networking"
++
+ 	"knative.dev/pkg/test/spoof"
+ 
+ 	corev1 "k8s.io/api/core/v1"
+@@ -83,6 +85,9 @@ func TestBYOCertificate(t *testing.T) {
+ 	secret, err := clients.KubeClient.CoreV1().Secrets(test.ServingFlags.TestNamespace).Create(ctx, &corev1.Secret{
+ 		ObjectMeta: metav1.ObjectMeta{
+ 			Name: test.AppendRandomString("byocert-secret"),
++			Labels: map[string]string{
++				networking.CertificateUIDLabelKey: "byocert-secret",
++			},
+ 		},
+ 		Type: corev1.SecretTypeTLS,
+ 		Data: map[string][]byte{


### PR DESCRIPTION
**What this PR does / why we need it**:

As secret filtering is only enabled in downstream Serverless Operator, we need to patch the domain_mapping_test to add the CertificateUID label to the certificate Secret created by the test. 