### PR TITLE
[WIP] Use multiarch Golang builder

### DIFF
--- a/openshift/ci-operator/Dockerfile.in
+++ b/openshift/ci-operator/Dockerfile.in
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/${bin} /ko-app/${bin}

--- a/openshift/ci-operator/Dockerfile_with_kodata.in
+++ b/openshift/ci-operator/Dockerfile_with_kodata.in
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 USER 65532
 
 COPY ${kodata_path} /var/run/ko

--- a/openshift/ci-operator/knative-images/activator/Dockerfile
+++ b/openshift/ci-operator/knative-images/activator/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 USER 65532
 
 COPY ./cmd/activator/kodata /var/run/ko

--- a/openshift/ci-operator/knative-images/autoscaler-hpa/Dockerfile
+++ b/openshift/ci-operator/knative-images/autoscaler-hpa/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 USER 65532
 
 COPY ./cmd/autoscaler-hpa/kodata /var/run/ko

--- a/openshift/ci-operator/knative-images/autoscaler/Dockerfile
+++ b/openshift/ci-operator/knative-images/autoscaler/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 USER 65532
 
 COPY ./cmd/autoscaler/kodata /var/run/ko

--- a/openshift/ci-operator/knative-images/controller/Dockerfile
+++ b/openshift/ci-operator/knative-images/controller/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 USER 65532
 
 COPY ./cmd/controller/kodata /var/run/ko

--- a/openshift/ci-operator/knative-images/migrate/Dockerfile
+++ b/openshift/ci-operator/knative-images/migrate/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/migrate /ko-app/migrate

--- a/openshift/ci-operator/knative-images/queue/Dockerfile
+++ b/openshift/ci-operator/knative-images/queue/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 USER 65532
 
 COPY ./cmd/queue/kodata /var/run/ko

--- a/openshift/ci-operator/knative-images/webhook/Dockerfile
+++ b/openshift/ci-operator/knative-images/webhook/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 USER 65532
 
 COPY ./cmd/webhook/kodata /var/run/ko

--- a/openshift/ci-operator/knative-test-images/autoscale/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/autoscale/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/autoscale /ko-app/autoscale

--- a/openshift/ci-operator/knative-test-images/failing/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/failing/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/failing /ko-app/failing

--- a/openshift/ci-operator/knative-test-images/grpc-ping/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/grpc-ping/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/grpc-ping /ko-app/grpc-ping

--- a/openshift/ci-operator/knative-test-images/hellohttp2/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/hellohttp2/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/hellohttp2 /ko-app/hellohttp2

--- a/openshift/ci-operator/knative-test-images/hellovolume/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/hellovolume/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/hellovolume /ko-app/hellovolume

--- a/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/helloworld/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/helloworld /ko-app/helloworld

--- a/openshift/ci-operator/knative-test-images/httpproxy/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/httpproxy/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/httpproxy /ko-app/httpproxy

--- a/openshift/ci-operator/knative-test-images/pizzaplanetv1/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/pizzaplanetv1/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/pizzaplanetv1 /ko-app/pizzaplanetv1

--- a/openshift/ci-operator/knative-test-images/pizzaplanetv2/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/pizzaplanetv2/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/pizzaplanetv2 /ko-app/pizzaplanetv2

--- a/openshift/ci-operator/knative-test-images/readiness/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/readiness/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/readiness /ko-app/readiness

--- a/openshift/ci-operator/knative-test-images/runtime/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/runtime/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/runtime /ko-app/runtime

--- a/openshift/ci-operator/knative-test-images/servingcontainer/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/servingcontainer/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/servingcontainer /ko-app/servingcontainer

--- a/openshift/ci-operator/knative-test-images/sidecarcontainer/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/sidecarcontainer/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/sidecarcontainer /ko-app/sidecarcontainer

--- a/openshift/ci-operator/knative-test-images/singlethreaded/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/singlethreaded/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/singlethreaded /ko-app/singlethreaded

--- a/openshift/ci-operator/knative-test-images/slowstart/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/slowstart/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/slowstart /ko-app/slowstart

--- a/openshift/ci-operator/knative-test-images/timeout/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/timeout/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/timeout /ko-app/timeout

--- a/openshift/ci-operator/knative-test-images/volumes/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/volumes/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/volumes /ko-app/volumes

--- a/openshift/ci-operator/knative-test-images/wsserver/Dockerfile
+++ b/openshift/ci-operator/knative-test-images/wsserver/Dockerfile
@@ -1,10 +1,10 @@
 # Do not edit! This file was generated via Makefile
-FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
 COPY . .
 RUN make install test-install
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal
 USER 65532
 
 COPY --from=builder /go/bin/wsserver /ko-app/wsserver

--- a/openshift/performance/patches/perf.patch
+++ b/openshift/performance/patches/perf.patch
@@ -36,30 +36,30 @@ index 57d918069..4da396560 100644
 
  # Generate an aggregated knative yaml file with replaced image references
 diff --git a/openshift/ci-operator/Dockerfile.in b/openshift/ci-operator/Dockerfile.in
-index 32b94bfb1..ce192d43d 100644
+index 8306bc91c..81265fa7a 100644
 --- a/openshift/ci-operator/Dockerfile.in
 +++ b/openshift/ci-operator/Dockerfile.in
 @@ -2,7 +2,7 @@
- FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+ FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
  COPY . .
 -RUN make install test-install
 +RUN make install test-install perf-install
 
- FROM registry.access.redhat.com/ubi8/ubi-minimal
+ FROM registry.access.redhat.com/ubi9/ubi-minimal
  USER 65532
 diff --git a/openshift/ci-operator/Dockerfile_with_kodata.in b/openshift/ci-operator/Dockerfile_with_kodata.in
-index 00de72095..0422ce541 100644
+index 3ab06ce3b..334c60534 100644
 --- a/openshift/ci-operator/Dockerfile_with_kodata.in
 +++ b/openshift/ci-operator/Dockerfile_with_kodata.in
 @@ -2,7 +2,7 @@
- FROM registry.ci.openshift.org/openshift/release:golang-1.21 as builder
+ FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16 as builder
 
  COPY . .
 -RUN make install test-install
 +RUN make install test-install perf-install
 
- FROM registry.access.redhat.com/ubi8/ubi-minimal
+ FROM registry.access.redhat.com/ubi9/ubi-minimal
  USER 65532
 diff --git a/test/performance/README.md b/test/performance/README.md
 index a4906039a..f17f7cffc 100644


### PR DESCRIPTION
**What this PR does / why we need it**:

Support ARM and be able to build Serving images in on a heterogenous cluster in CI.

Link to [Slack thread](https://redhat-internal.slack.com/archives/CB95J6R4N/p1709808404466339?thread_ts=1709807791.409639&cid=CB95J6R4N) where this new image was mentioned.

Note: The new image is available only in CI. If somebody wants to use those Dockerfiles and built images locally they need to have an authfile in json format (it's possible to download it from a running CI job).

Image metadata:
```
skopeo inspect --raw --authfile=dockerconfig.json docker://registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-builder-multi-openshift-4.16
{
    "manifests": [
        {
            "digest": "sha256:8c44fc7f6f3fcdd844f94f7aeba3e3fabb723943ce04dfce449960bf9c71a815",
            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
            "platform": {
                "architecture": "amd64",
                "os": "linux"
            },
            "size": 922
        },
        {
            "digest": "sha256:41a80f39d422fedb68d3462db6050ec0e19b2351f956cd6f97f624f7947684fb",
            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
            "platform": {
                "architecture": "arm64",
                "os": "linux"
            },
            "size": 922
        },
        {
            "digest": "sha256:7d6f9f7dd670f9ccb87d369ea52081937faa1e18b66a3187e16ef2f2ef3fd336",
            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
            "platform": {
                "architecture": "ppc64le",
                "os": "linux"
            },
            "size": 922
        },
        {
            "digest": "sha256:21957552890abebfdc42eee30982c690aa16e0c7d5032e3c063201a29ec055e7",
            "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
            "platform": {
                "architecture": "s390x",
                "os": "linux"
            },
            "size": 922
        }
    ],
    "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
    "schemaVersion": 2
}
```

**Which issue(s) this PR fixes**:

JIRA: https://issues.redhat.com/browse/SRVKS-1024

**Does this PR needs for other branches**:

release-v1.13, main
<!--
If no, just write "NONE".
If yes, add cherry-pick label:

/cherry-pick release-vX.Y
-->

/cherry-pick release-v1.13
/cherry-pick main

**Does this PR (patch) needs to update/drop in the future?**:

<!--
If no, just write "NONE".
If yes, please open the JIRA and link here:
-->

NONE
