### PR TITLE
[RELEASE-1.14] Incorporate upstream encryption changes to Serving

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ perf-tests:
 .PHONY: perf-tests
 
 test-e2e-tls:
-	ENABLE_INTERNAL_TLS="true" ./openshift/e2e-tests.sh
+	ENABLE_TLS="true" ./openshift/e2e-tests.sh
 .PHONY: test-e2e-tls
 
 # Target used by github actions.

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -151,13 +151,13 @@ function install_knative(){
     configure_cm network system-internal-tls:enabled || fail_test
     configure_cm network cluster-local-domain-tls:enabled || fail_test
 
-    echo "Restart activator to mount the certificates"
-    oc delete pod -n ${SERVING_NAMESPACE} -l app=activator
-    oc wait --timeout=60s --for=condition=Available deployment  -n ${SERVING_NAMESPACE} activator
-
     echo "Restart controller to enable cert-manager integration"
     oc delete pod -n ${SERVING_NAMESPACE} -l app=controller
     oc wait --timeout=60s --for=condition=Available deployment  -n ${SERVING_NAMESPACE} controller
+
+    echo "Restart activator to mount the certificates"
+    oc delete pod -n ${SERVING_NAMESPACE} -l app=activator
+    oc wait --timeout=60s --for=condition=Available deployment  -n ${SERVING_NAMESPACE} activator
 
     echo "cluster-local-domain-tls and system-internal-tls are ENABLED"
   else

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -118,8 +118,7 @@ function install_serverless(){
   # Use the absolute path for KNATIVE_SERVING_MANIFESTS_DIR. It is used in `make generated-files`.
   export KNATIVE_SERVING_MANIFESTS_DIR="$(pwd)/openshift/release/artifacts"
 
-  # TODO UNDO ME:
-  if ! git clone -b serving-tls-so --depth 1 https://github.com/retocode/serverless-operator.git ${SERVERLESS_DIR}; then
+  if ! git clone -b $(serverless_operator_version) --depth 1 https://github.com/openshift-knative/serverless-operator.git ${SERVERLESS_DIR}; then
      # As serving branch cuts before SO branch so it fails to clone the branch in the meantime.
      echo "Failed to clone $(serverless_operator_version) SO branch. Use main branch."
      git clone --depth 1 https://github.com/openshift-knative/serverless-operator.git ${SERVERLESS_DIR}

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -270,7 +270,7 @@ function run_e2e_tests(){
     existingTemplate=$(oc get cm -n "${SYSTEM_NAMESPACE}" config-observability -o jsonpath='{.data.logging\.request-log-template}' | sed 's/\"/\\"/g')
     patch_request_log_template "TLS: {{.Request.TLS}}" || fail_test
 
-    go_test_e2e -timeout=3m ./test/e2e/systeminternaltls \
+    go_test_e2e -timeout=5m ./test/e2e/systeminternaltls \
       --imagetemplate "$TEST_IMAGE_TEMPLATE" \
       ${OPENSHIFT_TEST_OPTIONS} || failed=1
 

--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -251,7 +251,7 @@ function run_e2e_tests(){
     parallel=2
   fi
 
-  go_test_e2e -tags=e2e -timeout=30m -parallel=$parallel \
+  go_test_e2e -tags=e2e -timeout=40m -parallel=$parallel \
     ./test/e2e ./test/conformance/api/... ./test/conformance/runtime/... \
     --imagetemplate "$TEST_IMAGE_TEMPLATE" \
     ${OPENSHIFT_TEST_OPTIONS} || failed=1
@@ -263,7 +263,7 @@ function run_e2e_tests(){
   disable_feature_flags tag-header-based-routing || fail_test
 
   if [[ ${ENABLE_TLS:-} == "true" ]]; then
-    go_test_e2e -timeout=2m ./test/e2e/clusterlocaldomaintls \
+    go_test_e2e -timeout=5m ./test/e2e/clusterlocaldomaintls \
       --imagetemplate "$TEST_IMAGE_TEMPLATE" \
       ${OPENSHIFT_TEST_OPTIONS} || failed=1
 

--- a/openshift/e2e-tests.sh
+++ b/openshift/e2e-tests.sh
@@ -3,8 +3,6 @@
 # shellcheck disable=SC1090
 source "$(dirname "$0")/e2e-common.sh"
 
-set -x
-
 env
 
 failed=0

--- a/openshift/patches/013-ocp-e2e-tests.patch
+++ b/openshift/patches/013-ocp-e2e-tests.patch
@@ -1,0 +1,15 @@
+diff --git a/test/e2e/clusterlocaldomaintls/cluster_local_domain_tls_test.go b/test/e2e/clusterlocaldomaintls/cluster_local_domain_tls_test.go
+--- a/test/e2e/clusterlocaldomaintls/cluster_local_domain_tls_test.go	(revision a35c0c4839e309e10f23c6d6c0fd72b44c491c7f)
++++ b/test/e2e/clusterlocaldomaintls/cluster_local_domain_tls_test.go	(revision eebdb4a9e34f66dbaece8f636578989d5748ae0f)
+@@ -129,8 +129,9 @@
+ 		t.Fatalf("Internal URL scheme of service %v was not https", names.Service)
+ 	}
+ 
+-	if externalURL.Scheme != "http" {
+-		t.Fatalf("External URL scheme of service %v was not http", names.Service)
++	// On OpenShift this is always https
++	if externalURL.Scheme != "https" {
++		t.Fatalf("External URL scheme of service %v was not https", names.Service)
+ 	}
+ 
+ 	// Check normal access on external domain

--- a/test/e2e/clusterlocaldomaintls/cluster_local_domain_tls_test.go
+++ b/test/e2e/clusterlocaldomaintls/cluster_local_domain_tls_test.go
@@ -129,8 +129,9 @@ func TestClusterLocalDomainTLSClusterExternalVisibility(t *testing.T) {
 		t.Fatalf("Internal URL scheme of service %v was not https", names.Service)
 	}
 
-	if externalURL.Scheme != "http" {
-		t.Fatalf("External URL scheme of service %v was not http", names.Service)
+	// On OpenShift this is always https
+	if externalURL.Scheme != "https" {
+		t.Fatalf("External URL scheme of service %v was not https", names.Service)
 	}
 
 	// Check normal access on external domain


### PR DESCRIPTION
Fixes JIRA https://issues.redhat.com/browse/SRVKS-1198

# Changes
- Rename `ENABLE_INTERNAL_TLS` -> `ENABLE_TLS`
- Use the new flags `cluster-local-domain-tls` and `system-internal-tls`
- Drop old, now unused configs/secrets
- Run upstream tests `clusterlocaldomaintls` and `systeminternaltls`
- Add patches to make these tests run on OCP

Patches will be ported to main on a separate PR.

