### PR TITLE
Enable multi-container probing tests in openshift/e2e-common.sh

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -302,6 +302,12 @@ function run_e2e_tests(){
   configure_cm deployment progressDeadline:120s || fail_test
   disable_feature_flags kubernetes.podspec-persistent-volume-claim kubernetes.podspec-persistent-volume-write kubernetes.podspec-securitycontext || fail_test
 
+  enable_feature_flags multi-container-probing || fail_test
+  go_test_e2e -timeout=2m ./test/e2e/multicontainerprobing \
+    --imagetemplate "$TEST_IMAGE_TEMPLATE" \
+    ${OPENSHIFT_TEST_OPTIONS} || failed=$?
+  disable_feature_flags multi-container-probing || fail_test
+
   # Run the helloworld test with an image pulled into the internal registry.
   local image_to_tag=$KNATIVE_SERVING_TEST_HELLOWORLD
   oc tag -n serving-tests "$image_to_tag" "helloworld:latest" --reference-policy=local


### PR DESCRIPTION
**What this PR does / why we need it**:

This is the openshift-related change from https://github.com/openshift-knative/serving/pull/710 that should be applied in scripts when creating new branches.

**Which issue(s) this PR fixes**:

JIRA:

**Does this PR needs for other branches**:

<!--
If no, just write "NONE".
If yes, add cherry-pick label:

/cherry-pick release-vX.Y
-->

**Does this PR (patch) needs to update/drop in the future?**:

<!--
If no, just write "NONE".
If yes, please open the JIRA and link here:
-->

JIRA:
