### PR TITLE
[RELEASE-1.14] Backport: Do not delete ingress Secret in tests for internal tls

### DIFF
--- a/test/e2e/systeminternaltls/system_internal_tls_test.go
+++ b/test/e2e/systeminternaltls/system_internal_tls_test.go
@@ -227,12 +227,6 @@ func TestTLSCertificateRotation(t *testing.T) {
 		t.Fatalf("Failed to delete secret %s in system namespacee", config.ServingRoutingCertName)
 	}
 	checkEndpointState(t, clients, url)
-
-	t.Log("Deleting secret in ingress namespace")
-	if err := clients.KubeClient.CoreV1().Secrets(ingressNS).Delete(context.Background(), config.ServingRoutingCertName, v1.DeleteOptions{}); err != nil {
-		t.Fatalf("Failed to delete secret %s in ingress namespacee", config.ServingRoutingCertName)
-	}
-	checkEndpointState(t, clients, url)
 }
 
 func checkEndpointState(t *testing.T, clients *test.Clients, url *url.URL) {


### PR DESCRIPTION
# Changes
- Backport of https://github.com/knative/serving/pull/15280

/assign @mgencur 
