### PR TITLE
Do not run TestTLSCertificateRotation in parallel with other tests

### DIFF
--- a/test/e2e/systeminternaltls/system_internal_tls_test.go
+++ b/test/e2e/systeminternaltls/system_internal_tls_test.go
@@ -122,8 +122,6 @@ func TestTLSCertificateRotation(t *testing.T) {
 		t.Skip("Skip this test for non-kourier or non-istio ingress.")
 	}
 
-	t.Parallel()
-
 	clients := test.Setup(t)
 
 	names := test.ResourceNames{


### PR DESCRIPTION
Backport from upstream.

This test deletes the serving-tests/serving-certs during the test run. This might break the other test TestSystemInternalTLS because it waits for certain log lines to appear in the service pods. Deleting the serving-certs secret causes the application pods to be deleted so that the new cert can be mounted. And waiting for given log lines then fails because the pod no longer exists:
system_internal_tls_test.go:110: TLS not used on requests to queue-proxy: pods
"system-internal-tls-wgvxqtyx-00001-deployment-6fdc4c8c7d-4ll8q" not found

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

JIRA:

**Does this PR needs for other branches**:

<!--
If no, just write "NONE".
If yes, add cherry-pick label:

/cherry-pick release-vX.Y
-->

**Does this PR (patch) needs to update/drop in the future?**:

<!--
If no, just write "NONE".
If yes, please open the JIRA and link here:
-->

JIRA:
