### PR TITLE
[main] Remove go install from build image

### DIFF
--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -10,12 +10,5 @@ RUN yum install -y kubectl httpd-tools
 # Serverless-Operator `make generated-files` needs helm
 RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
 
-RUN GOFLAGS='' go install github.com/mikefarah/yq/v3@latest
-RUN GOFLAGS='' go install knative.dev/test-infra/tools/kntest/cmd/kntest@latest
-
-# go install creates $GOPATH/.cache with root permissions, we delete it here
-# to avoid permission issues with the runtime users
-RUN rm -rf $GOPATH/.cache
-
 # Allow runtime users to add entries to /etc/passwd
 RUN chmod g+rw /etc/passwd


### PR DESCRIPTION
**What this PR does / why we need it**:
* Fixes build issues we have with go 1.22 image combined with upstream vendorless changes
* Full discussion [here](https://redhat-internal.slack.com/archives/C03GE6RQ2QY/p1722390670514649)
* Tested with https://github.com/openshift-knative/serving/pull/781 and https://github.com/openshift-knative/serving/pull/783

**Does this PR needs for other branches**:

No, will break for 1.15, which is not cut yet

