### PR TITLE
[release-v1.15] Add missing changes from #702

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ perf-tests:
 .PHONY: perf-tests
 
 test-e2e-tls:
-	ENABLE_INTERNAL_TLS="true" ./openshift/e2e-tests.sh
+	ENABLE_TLS="true" ./openshift/e2e-tests.sh
 .PHONY: test-e2e-tls
 
 # Target used by github actions.

--- a/openshift/e2e-tests.sh
+++ b/openshift/e2e-tests.sh
@@ -7,7 +7,7 @@ env
 
 failed=0
 
-export ENABLE_INTERNAL_TLS="${ENABLE_INTERNAL_TLS:-false}"
+export ENABLE_TLS="${ENABLE_TLS:-false}"
 
 (( !failed )) && install_knative || failed=1
 (( !failed )) && prepare_knative_serving_tests_nightly || failed=2

--- a/openshift/e2e-tests.sh
+++ b/openshift/e2e-tests.sh
@@ -3,8 +3,6 @@
 # shellcheck disable=SC1090
 source "$(dirname "$0")/e2e-common.sh"
 
-set -x
-
 env
 
 failed=0

--- a/openshift/patches/014-ocp-system-internal-tls-test.patch
+++ b/openshift/patches/014-ocp-system-internal-tls-test.patch
@@ -1,0 +1,67 @@
+diff --git a/test/e2e/systeminternaltls/system_internal_tls_test.go b/test/e2e/systeminternaltls/system_internal_tls_test.go
+--- a/test/e2e/systeminternaltls/system_internal_tls_test.go	(revision 9d0fa738d33402b893659610ddf4d4635cfa61f4)
++++ b/test/e2e/systeminternaltls/system_internal_tls_test.go	(revision 4f646561395fb011368360e35365f8664383cdc5)
+@@ -113,6 +113,7 @@
+
+ // TestTLSCertificateRotation tests certificate rotation and automatic reloading of certs.
+ func TestTLSCertificateRotation(t *testing.T) {
++
+ 	if !test.ServingFlags.EnableAlphaFeatures {
+ 		t.Skip("Alpha features not enabled")
+ 	}
+@@ -162,6 +163,7 @@
+
+ 	t.Log("Creating ConfigMap with old and new CA certs")
+ 	systemNS := os.Getenv(system.NamespaceEnvKey)
++	ingressNS := os.Getenv(test.GatewayNamespaceOverride)
+
+ 	// Create ConfigMap with networking.knative.dev/trust-bundle label in required namespaces
+ 	cm := &corev1.ConfigMap{
+@@ -179,7 +181,15 @@
+ 	_, err = clients.KubeClient.CoreV1().ConfigMaps(systemNS).
+ 		Create(context.Background(), cm, v1.CreateOptions{})
+ 	if err != nil {
+-		t.Fatal("Failed to create configmap:", err)
++		t.Fatal("Failed to create configmap in "+systemNS, err)
++	}
++
++	if ingressNS != "" && systemNS != ingressNS {
++		_, err = clients.KubeClient.CoreV1().ConfigMaps(ingressNS).
++			Create(context.Background(), cm, v1.CreateOptions{})
++		if err != nil {
++			t.Fatal("Failed to create configmap in "+ingressNS, err)
++		}
+ 	}
+
+ 	// Clean up on test failure or interrupt
+@@ -187,7 +197,14 @@
+ 		test.TearDown(clients, &names)
+ 		if err := clients.KubeClient.CoreV1().ConfigMaps(systemNS).
+ 			Delete(context.Background(), cm.Name, v1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+-			t.Fatal("Failed to delete configmap:", err)
++			t.Fatal("Failed to delete configmap in "+systemNS, err)
++		}
++
++		if ingressNS != "" && systemNS != ingressNS {
++			if err := clients.KubeClient.CoreV1().ConfigMaps(ingressNS).
++				Delete(context.Background(), cm.Name, v1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
++				t.Fatal("Failed to delete configmap in "+ingressNS, err)
++			}
+ 		}
+ 	})
+
+@@ -218,6 +235,14 @@
+ 	if err := clients.KubeClient.CoreV1().Secrets(systemNS).Delete(context.Background(), config.ServingRoutingCertName, v1.DeleteOptions{}); err != nil {
+ 		t.Fatalf("Failed to delete secret %s in system namespace: %v", config.ServingRoutingCertName, err)
+ 	}
++
++	if ingressNS != "" && systemNS != ingressNS {
++		t.Log("Deleting secret in ingress namespace")
++		if err := clients.KubeClient.CoreV1().Secrets(ingressNS).Delete(context.Background(), config.ServingRoutingCertName, v1.DeleteOptions{}); err != nil {
++			t.Fatalf("Failed to delete secret %s in ingress namespace: %v", config.ServingRoutingCertName, err)
++		}
++	}
++
+ 	checkEndpointState(t, clients, url)
+ }
+

--- a/test/e2e/systeminternaltls/system_internal_tls_test.go
+++ b/test/e2e/systeminternaltls/system_internal_tls_test.go
@@ -113,6 +113,7 @@ func TestSystemInternalTLS(t *testing.T) {
 
 // TestTLSCertificateRotation tests certificate rotation and automatic reloading of certs.
 func TestTLSCertificateRotation(t *testing.T) {
+
 	if !test.ServingFlags.EnableAlphaFeatures {
 		t.Skip("Alpha features not enabled")
 	}
@@ -162,6 +163,7 @@ func TestTLSCertificateRotation(t *testing.T) {
 
 	t.Log("Creating ConfigMap with old and new CA certs")
 	systemNS := os.Getenv(system.NamespaceEnvKey)
+	ingressNS := os.Getenv(test.GatewayNamespaceOverride)
 
 	// Create ConfigMap with networking.knative.dev/trust-bundle label in required namespaces
 	cm := &corev1.ConfigMap{
@@ -179,7 +181,15 @@ func TestTLSCertificateRotation(t *testing.T) {
 	_, err = clients.KubeClient.CoreV1().ConfigMaps(systemNS).
 		Create(context.Background(), cm, v1.CreateOptions{})
 	if err != nil {
-		t.Fatal("Failed to create configmap:", err)
+		t.Fatal("Failed to create configmap in "+systemNS, err)
+	}
+
+	if ingressNS != "" && systemNS != ingressNS {
+		_, err = clients.KubeClient.CoreV1().ConfigMaps(ingressNS).
+			Create(context.Background(), cm, v1.CreateOptions{})
+		if err != nil {
+			t.Fatal("Failed to create configmap in "+ingressNS, err)
+		}
 	}
 
 	// Clean up on test failure or interrupt
@@ -187,7 +197,14 @@ func TestTLSCertificateRotation(t *testing.T) {
 		test.TearDown(clients, &names)
 		if err := clients.KubeClient.CoreV1().ConfigMaps(systemNS).
 			Delete(context.Background(), cm.Name, v1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
-			t.Fatal("Failed to delete configmap:", err)
+			t.Fatal("Failed to delete configmap in "+systemNS, err)
+		}
+
+		if ingressNS != "" && systemNS != ingressNS {
+			if err := clients.KubeClient.CoreV1().ConfigMaps(ingressNS).
+				Delete(context.Background(), cm.Name, v1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+				t.Fatal("Failed to delete configmap in "+ingressNS, err)
+			}
 		}
 	})
 
@@ -218,6 +235,14 @@ func TestTLSCertificateRotation(t *testing.T) {
 	if err := clients.KubeClient.CoreV1().Secrets(systemNS).Delete(context.Background(), config.ServingRoutingCertName, v1.DeleteOptions{}); err != nil {
 		t.Fatalf("Failed to delete secret %s in system namespace: %v", config.ServingRoutingCertName, err)
 	}
+
+	if ingressNS != "" && systemNS != ingressNS {
+		t.Log("Deleting secret in ingress namespace")
+		if err := clients.KubeClient.CoreV1().Secrets(ingressNS).Delete(context.Background(), config.ServingRoutingCertName, v1.DeleteOptions{}); err != nil {
+			t.Fatalf("Failed to delete secret %s in ingress namespace: %v", config.ServingRoutingCertName, err)
+		}
+	}
+
 	checkEndpointState(t, clients, url)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Includes https://github.com/openshift-knative/serving/pull/801
- And a fix for the failing e2e-tls tests: https://github.com/openshift-knative/serving/pull/871/commits/d96521b6bde57db94b1bd79397dfc2906eb385dd

**Does this PR needs for other branches**:

1.14 contains a fix upstream, but the env var in the script is still wrong. I'll port the missing bits to 1.14 and main manually.

**Does this PR (patch) needs to update/drop in the future?**:
No


/assign @skonto 