### PR TITLE
[RELEASE-1.15] Back-port upstream istio.sidecar.inject labels

### DIFF
--- a/config/post-install/cleanup.yaml
+++ b/config/post-install/cleanup.yaml
@@ -27,13 +27,12 @@ spec:
   backoffLimit: 10
   template:
     metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
       labels:
         app: cleanup-migration-serving
         app.kubernetes.io/name: knative-serving
         app.kubernetes.io/component: cleanup-job
         app.kubernetes.io/version: devel
+        sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: controller
       restartPolicy: OnFailure

--- a/config/post-install/default-domain.yaml
+++ b/config/post-install/default-domain.yaml
@@ -25,13 +25,12 @@ metadata:
 spec:
   template:
     metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
       labels:
         app: "default-domain"
         app.kubernetes.io/component: default-domain-job
         app.kubernetes.io/name: knative-serving
         app.kubernetes.io/version: devel
+        sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: controller
       containers:

--- a/config/post-install/storage-version-migration.yaml
+++ b/config/post-install/storage-version-migration.yaml
@@ -27,13 +27,12 @@ spec:
   backoffLimit: 10
   template:
     metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
       labels:
         app: storage-version-migration-serving
         app.kubernetes.io/name: knative-serving
         app.kubernetes.io/component: storage-version-migration-job
         app.kubernetes.io/version: devel
+        sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: controller
       restartPolicy: OnFailure

--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -19,6 +19,7 @@ RUN wget https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && 
 RUN ./get-helm-3 --version v3.11.3 --no-sudo && helm version
 
 RUN GOFLAGS='' go install github.com/mikefarah/yq/v3@latest
+RUN GOFLAGS='' go install -tags="exclude_graphdriver_btrfs containers_image_openpgp" github.com/containers/skopeo/cmd/skopeo@v1.16.1
 
 # go install creates $GOPATH/.cache with root permissions, we delete it here
 # to avoid permission issues with the runtime users

--- a/openshift/patches/015-backport-istio-label.patch
+++ b/openshift/patches/015-backport-istio-label.patch
@@ -1,0 +1,16 @@
+diff --git a/vendor/knative.dev/pkg/test/crd.go b/vendor/knative.dev/pkg/test/crd.go
+--- a/vendor/knative.dev/pkg/test/crd.go	(revision d7619a7227b4f696e05deb55a3b3319742c11225)
++++ b/vendor/knative.dev/pkg/test/crd.go	(date 1727352218633)
+@@ -74,9 +74,9 @@
+ func NginxPod(namespace string) *corev1.Pod {
+ 	return &corev1.Pod{
+ 		ObjectMeta: metav1.ObjectMeta{
+-			Name:        nginxName,
+-			Namespace:   namespace,
+-			Annotations: map[string]string{"sidecar.istio.io/inject": "true"},
++			Name:      nginxName,
++			Namespace: namespace,
++			Labels:    map[string]string{"sidecar.istio.io/inject": "true"},
+ 		},
+ 		Spec: corev1.PodSpec{
+ 			Containers: []corev1.Container{

--- a/openshift/release/artifacts/serving-post-install-jobs.yaml
+++ b/openshift/release/artifacts/serving-post-install-jobs.yaml
@@ -28,13 +28,12 @@ spec:
   backoffLimit: 10
   template:
     metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
       labels:
         app: storage-version-migration-serving
         app.kubernetes.io/name: knative-serving
         app.kubernetes.io/component: storage-version-migration-job
         app.kubernetes.io/version: "v1.15"
+        sidecar.istio.io/inject: "false"
     spec:
       serviceAccountName: controller
       restartPolicy: OnFailure

--- a/pkg/reconciler/revision/resources/deploy_test.go
+++ b/pkg/reconciler/revision/resources/deploy_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"knative.dev/pkg/kmap"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -48,11 +49,11 @@ import (
 )
 
 var (
-	servingContainerName         = "serving-container"
-	sidecarContainerName         = "sidecar-container-1"
-	sidecarContainerName2        = "sidecar-container-2"
-	sidecarIstioInjectAnnotation = "sidecar.istio.io/inject"
-	defaultServingContainer      = &corev1.Container{
+	servingContainerName    = "serving-container"
+	sidecarContainerName    = "sidecar-container-1"
+	sidecarContainerName2   = "sidecar-container-2"
+	sidecarIstioInjectLabel = "sidecar.istio.io/inject"
+	defaultServingContainer = &corev1.Container{
 		Name:                     servingContainerName,
 		Image:                    "busybox",
 		Ports:                    buildContainerPorts(v1.DefaultUserPort),
@@ -1786,16 +1787,16 @@ func TestMakeDeployment(t *testing.T) {
 			WithContainerStatuses([]v1.ContainerStatus{{
 				ImageDigest: "busybox@sha256:deadbeef",
 			}}),
-			withoutLabels, func(revision *v1.Revision) {
-				revision.Annotations = map[string]string{
-					sidecarIstioInjectAnnotation: "false",
+			func(revision *v1.Revision) {
+				revision.Labels = map[string]string{
+					sidecarIstioInjectLabel: "false",
 				}
 			}),
 		want: appsv1deployment(func(deploy *appsv1.Deployment) {
-			deploy.Annotations = kmeta.UnionMaps(deploy.Annotations,
-				map[string]string{sidecarIstioInjectAnnotation: "false"})
-			deploy.Spec.Template.Annotations = kmeta.UnionMaps(deploy.Spec.Template.Annotations,
-				map[string]string{sidecarIstioInjectAnnotation: "false"})
+			deploy.Labels = kmap.Union(deploy.Labels,
+				map[string]string{sidecarIstioInjectLabel: "false"})
+			deploy.Spec.Template.Labels = kmap.Union(deploy.Spec.Template.Labels,
+				map[string]string{sidecarIstioInjectLabel: "false"})
 		}),
 	}, {
 		name: "with progress-deadline override",

--- a/test/config/externaldomaintls/certmanager/http01/mesh-issuer.yaml
+++ b/test/config/externaldomaintls/certmanager/http01/mesh-issuer.yaml
@@ -26,9 +26,8 @@ spec:
          ingress:
            podTemplate:
             metadata:
-              annotations:
-                sidecar.istio.io/inject: "true"
               labels:
+                sidecar.istio.io/inject: "true"
                 # Istio adds the Challenge name for the value of this label.
                 # And the challenge name is sometimes more than 63 characters.
                 # So we override this label with empty value.

--- a/test/e2e/httpproxy.go
+++ b/test/e2e/httpproxy.go
@@ -79,9 +79,7 @@ func TestProxyToHelloworld(t *testing.T, clients *test.Clients, helloworldURL *u
 
 	serviceOptions := []rtesting.ServiceOption{
 		rtesting.WithEnv(envVars...),
-		rtesting.WithConfigAnnotations(map[string]string{
-			"sidecar.istio.io/inject": strconv.FormatBool(inject),
-		}),
+		rtesting.WithServiceLabel("sidecar.istio.io/inject", strconv.FormatBool(inject)),
 	}
 
 	resources, err := v1test.CreateServiceReady(t, clients, &names, serviceOptions...)

--- a/test/e2e/service_to_service_test.go
+++ b/test/e2e/service_to_service_test.go
@@ -138,13 +138,14 @@ func testSvcToSvcCallViaActivator(t *testing.T, clients *test.Clients, injectA b
 	withInternalVisibility := rtesting.WithServiceLabel(
 		netapi.VisibilityLabelKey, serving.VisibilityClusterLocal)
 
+	withIstioSidecarInject := rtesting.WithServiceLabel("sidecar.istio.io/inject", strconv.FormatBool(injectB))
+
 	test.EnsureTearDown(t, clients, &testNames)
 
 	resources, err := v1test.CreateServiceReady(t, clients, &testNames,
 		rtesting.WithConfigAnnotations(map[string]string{
 			autoscaling.TargetBurstCapacityKey: "-1",
-			"sidecar.istio.io/inject":          strconv.FormatBool(injectB),
-		}), withInternalVisibility)
+		}), withInternalVisibility, withIstioSidecarInject)
 	if err != nil {
 		t.Fatal("Failed to create a service:", err)
 	}

--- a/third_party/istio-latest/net-istio.yaml
+++ b/third_party/istio-latest/net-istio.yaml
@@ -1,4 +1,4 @@
-# Generated when HEAD was 01930f2970a667754749b026f416eaac841aa506
+# Generated when HEAD was e6259b981b9a0b437e4f9094eeb85c79068c45b4
 #
 # Copyright 2019 The Knative Authors
 #
@@ -22,7 +22,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "20240722-01930f29"
+    app.kubernetes.io/version: "20240926-e6259b98"
     serving.knative.dev/controller: "true"
     networking.knative.dev/ingress-provider: istio
 rules:
@@ -54,7 +54,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "20240722-01930f29"
+    app.kubernetes.io/version: "20240926-e6259b98"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -93,7 +93,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "20240722-01930f29"
+    app.kubernetes.io/version: "20240926-e6259b98"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -114,7 +114,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "20240722-01930f29"
+    app.kubernetes.io/version: "20240926-e6259b98"
     networking.knative.dev/ingress-provider: istio
     experimental.istio.io/disable-gateway-port-translation: "true"
 spec:
@@ -152,7 +152,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "20240722-01930f29"
+    app.kubernetes.io/version: "20240926-e6259b98"
     networking.knative.dev/ingress-provider: istio
 data:
   # TODO(nghia): Extract the .svc.cluster.local suffix into its own config.
@@ -262,7 +262,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "20240722-01930f29"
+    app.kubernetes.io/version: "20240926-e6259b98"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -280,7 +280,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "20240722-01930f29"
+    app.kubernetes.io/version: "20240926-e6259b98"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -313,7 +313,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "20240722-01930f29"
+    app.kubernetes.io/version: "20240926-e6259b98"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -321,23 +321,22 @@ spec:
       app: net-istio-controller
   template:
     metadata:
-      annotations:
+      labels:
         # This must be outside of the mesh to probe the gateways.
         # NOTE: this is allowed here and not elsewhere because
         # this is the Istio controller, and so it may be Istio-aware.
         sidecar.istio.io/inject: "false"
-      labels:
         app: net-istio-controller
         app.kubernetes.io/component: net-istio
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "20240722-01930f29"
+        app.kubernetes.io/version: "20240926-e6259b98"
     spec:
       serviceAccountName: controller
       containers:
         - name: controller
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-nightly/knative.dev/net-istio/cmd/controller@sha256:d0b4d332960eae8aefba4acc3d5aa83944f47625cebad7cdf506148497e5d777
+          image: gcr.io/knative-nightly/knative.dev/net-istio/cmd/controller@sha256:066394f2a29eb1390c70e03d5740dac42387c87af970efb8e9eb6cf1b7a30419
           resources:
             requests:
               cpu: 30m
@@ -416,7 +415,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "20240722-01930f29"
+    app.kubernetes.io/version: "20240926-e6259b98"
     networking.knative.dev/ingress-provider: istio
 spec:
   selector:
@@ -430,14 +429,14 @@ spec:
         role: net-istio-webhook
         app.kubernetes.io/component: net-istio
         app.kubernetes.io/name: knative-serving
-        app.kubernetes.io/version: "20240722-01930f29"
+        app.kubernetes.io/version: "20240926-e6259b98"
     spec:
       serviceAccountName: controller
       containers:
         - name: webhook
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/knative-nightly/knative.dev/net-istio/cmd/webhook@sha256:9b2517cb8d74c4eb4345e6d9bece1a6ad62df1b4941de0c6a434e6ff942ebc50
+          image: gcr.io/knative-nightly/knative.dev/net-istio/cmd/webhook@sha256:22a6af6af868af63583e2fe9fc75a3af12a5eaa91cfe0339c933a67c579d7289
           resources:
             requests:
               cpu: 20m
@@ -515,7 +514,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "20240722-01930f29"
+    app.kubernetes.io/version: "20240926-e6259b98"
     networking.knative.dev/ingress-provider: istio
 
 ---
@@ -542,7 +541,7 @@ metadata:
     role: net-istio-webhook
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "20240722-01930f29"
+    app.kubernetes.io/version: "20240926-e6259b98"
     networking.knative.dev/ingress-provider: istio
 spec:
   ports:
@@ -581,7 +580,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "20240722-01930f29"
+    app.kubernetes.io/version: "20240926-e6259b98"
     networking.knative.dev/ingress-provider: istio
 webhooks:
   - admissionReviewVersions:
@@ -620,7 +619,7 @@ metadata:
   labels:
     app.kubernetes.io/component: net-istio
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "20240722-01930f29"
+    app.kubernetes.io/version: "20240926-e6259b98"
     networking.knative.dev/ingress-provider: istio
 webhooks:
   - admissionReviewVersions:

--- a/vendor/knative.dev/pkg/test/crd.go
+++ b/vendor/knative.dev/pkg/test/crd.go
@@ -74,9 +74,9 @@ func CoreV1ObjectReference(kind, apiversion, name string) *corev1.ObjectReferenc
 func NginxPod(namespace string) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        nginxName,
-			Namespace:   namespace,
-			Annotations: map[string]string{"sidecar.istio.io/inject": "true"},
+			Name:      nginxName,
+			Namespace: namespace,
+			Labels:    map[string]string{"sidecar.istio.io/inject": "true"},
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{


### PR DESCRIPTION
**What this PR does / why we need it**:
Back-ports:
- https://github.com/knative/serving/pull/15522
- Partially: https://github.com/knative/serving/commit/ff475dffe5c9815e4e9f5205a711a9bbc00a1291 (no go.mod, just the code diff + a patch)
- https://github.com/knative/serving/pull/15533

**Which issue(s) this PR fixes**:

JIRA: https://issues.redhat.com/browse/SRVKS-1273

**Does this PR needs for other branches**:
No, will be included from 1.16+ from upstream

**Does this PR (patch) needs to update/drop in the future?**:
No

/assign @skonto 