### PR TITLE
[RELEASE-1.15] Remove "DELETE" from the Serving validating webhook

### DIFF
--- a/config/core/webhooks/resource-validation.yaml
+++ b/config/core/webhooks/resource-validation.yaml
@@ -40,7 +40,6 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
-    - DELETE
     scope: "*"
     resources:
     - metrics

--- a/openshift/ci-operator/build-image/Dockerfile
+++ b/openshift/ci-operator/build-image/Dockerfile
@@ -19,7 +19,7 @@ RUN wget https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && 
 RUN ./get-helm-3 --version v3.11.3 --no-sudo && helm version
 
 RUN GOFLAGS='' go install github.com/mikefarah/yq/v3@latest
-RUN GOFLAGS='' go install -tags="exclude_graphdriver_btrfs containers_image_openpgp" github.com/containers/skopeo/cmd/skopeo@v1.16.1
+RUN GOFLAGS='' go install -tags="exclude_graphdriver_btrfs containers_image_openpgp" github.com/containers/skopeo/cmd/skopeo@v1.17.0
 
 # go install creates $GOPATH/.cache with root permissions, we delete it here
 # to avoid permission issues with the runtime users

--- a/openshift/patches/016-remove-delete-validation-webhook.patch
+++ b/openshift/patches/016-remove-delete-validation-webhook.patch
@@ -1,0 +1,12 @@
+diff --git a/config/core/webhooks/resource-validation.yaml b/config/core/webhooks/resource-validation.yaml
+index b49665420..2fdc8e2f8 100644
+--- a/config/core/webhooks/resource-validation.yaml
++++ b/config/core/webhooks/resource-validation.yaml
+@@ -40,7 +40,6 @@ webhooks:
+     operations:
+     - CREATE
+     - UPDATE
+-    - DELETE
+     scope: "*"
+     resources:
+     - metrics

--- a/openshift/release/artifacts/serving-core.yaml
+++ b/openshift/release/artifacts/serving-core.yaml
@@ -9264,7 +9264,6 @@ webhooks:
     operations:
     - CREATE
     - UPDATE
-    - DELETE
     scope: "*"
     resources:
     - metrics


### PR DESCRIPTION
* See discussion [here](https://redhat-internal.slack.com/archives/CF5ANN61F/p1737749678569649?thread_ts=1734022394.094999&cid=CF5ANN61F)
* This has been kept upstream for compatibility reasons but could cause issues during deletion.
* We want to avoid a scenario where due to foreground deletion the webhook deployment is removed before a certificate resource is deleted e.g. `routing-serving-certs`.
