### PR TITLE
Add update-deps.sh call to generate-release

### DIFF
--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-root="$(dirname "${BASH_SOURCE[0]}")"
+root="$(dirname "${BASH_SOURCE[0]}")"/../..
 
 source $(dirname $0)/resolve.sh
 
@@ -8,6 +8,13 @@ release=$(yq r openshift/project.yaml project.tag)
 release=${release/knative-/}
 
 echo "Release: $release"
+
+# Reconcile dependencies in case of dependabot updates
+"${root}"/hack/update-deps.sh
+# Re-applu patches that touch vendor/ dir
+git apply "${root}"/openshift/patches/001-object.patch
+git apply "${root}"/openshift/patches/002-mutemetrics.patch
+git apply "${root}"/openshift/patches/003-routeretry.patch
 
 ./openshift/generate.sh
 

--- a/openshift/release/generate-release.sh
+++ b/openshift/release/generate-release.sh
@@ -11,7 +11,7 @@ echo "Release: $release"
 
 # Reconcile dependencies in case of dependabot updates
 "${root}"/hack/update-deps.sh
-# Re-applu patches that touch vendor/ dir
+# Re-apply patches that touch vendor/ dir
 git apply "${root}"/openshift/patches/001-object.patch
 git apply "${root}"/openshift/patches/002-mutemetrics.patch
 git apply "${root}"/openshift/patches/003-routeretry.patch


### PR DESCRIPTION
#### Changes
- Add update-deps.sh call to generate-release

Enable dependabot bump to reconcile go.mod and common clean we do for updating deps.

/cc @skonto 