### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for kn-serving-autoscaler-hpa-116

### DIFF
--- a/openshift/ci-operator/knative-images/autoscaler-hpa/Dockerfile
+++ b/openshift/ci-operator/knative-images/autoscaler-hpa/Dockerfile
@@ -23,13 +23,14 @@ USER 65532
 
 LABEL \
       com.redhat.component="openshift-serverless-1-serving-autoscaler-hpa-rhel8-container" \
-      name="openshift-serverless-1/serving-autoscaler-hpa-rhel8" \
+      name="openshift-serverless-1/kn-serving-autoscaler-hpa-rhel8" \
       version=$VERSION \
       summary="Red Hat OpenShift Serverless 1 Serving Autoscaler Hpa" \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Serving Autoscaler Hpa" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Autoscaler Hpa" \
       io.k8s.description="Red Hat OpenShift Serverless Serving Autoscaler Hpa" \
-      io.openshift.tags="autoscaler-hpa"
+      io.openshift.tags="autoscaler-hpa" \
+      cpe="cpe:/a:redhat:openshift_serverless:1.36::el8"
 
 ENTRYPOINT ["/ko-app/autoscaler-hpa"]


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
