### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for kn-serving-storage-version-migration-115

### DIFF
--- a/openshift/ci-operator/knative-images/migrate/Dockerfile
+++ b/openshift/ci-operator/knative-images/migrate/Dockerfile
@@ -23,11 +23,12 @@ USER 65532
 
 LABEL \
       com.redhat.component="openshift-serverless-1-serving-migrate-rhel8-container" \
-      name="openshift-serverless-1/serving-migrate-rhel8" \
+      name="openshift-serverless-1/kn-serving-storage-version-migration-rhel8" \
       version=$VERSION \
       summary="Red Hat OpenShift Serverless 1 Serving Migrate" \
       maintainer="serverless-support@redhat.com" \
       description="Red Hat OpenShift Serverless 1 Serving Migrate" \
+      cpe="cpe:/a:redhat:openshift_serverless:1.35::el8" \
       io.k8s.display-name="Red Hat OpenShift Serverless 1 Serving Migrate" \
       io.k8s.description="Red Hat OpenShift Serverless Serving Migrate" \
       io.openshift.tags="migrate"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
