### PR TITLE
[release-v1.17] SO main move on-cluster builds namespace

### DIFF
--- a/openshift/e2e-common.sh
+++ b/openshift/e2e-common.sh
@@ -129,7 +129,7 @@ function install_serverless(){
   create_namespaces "${SYSTEM_NAMESPACES[@]}"
   export GOPATH=/tmp/go
   export ON_CLUSTER_BUILDS=true
-  export DOCKER_REPO_OVERRIDE=image-registry.openshift-image-registry.svc:5000/openshift-marketplace
+  export DOCKER_REPO_OVERRIDE=image-registry.openshift-image-registry.svc:5000/openshift-serverless-builds
   OPENSHIFT_CI="true" make generated-files images install-serving || return $?
 
  # Ensure tests trust the OpenShift router CA


### PR DESCRIPTION
Since https://github.com/openshift-knative/serverless-operator/commit/083f319e5303ea3d4f0e0ab95eaa39795fc6b8cb we use openshift-serverless-builds namespace for on-cluster builds in SO