### PR TITLE
[release v1.21] prometheus autoscaler/activator hacks

### DIFF
--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -236,7 +236,7 @@ func main() {
 	go activator.ReportStats(logger, statSink, statCh)
 
 	// Create and run our concurrency reporter
-	concurrencyReporter := activatorhandler.NewConcurrencyReporter(ctx, env.PodName, statCh, mp)
+	concurrencyReporter := activatorhandler.NewConcurrencyReporter(ctx, env.PodName, statCh, mp, usePrometheus)
 	go concurrencyReporter.Run(ctx.Done())
 
 	// Create activation handler chain
@@ -299,7 +299,7 @@ func main() {
 					return
 				}
 				if rev, ok := acc.(*v1.Revision); ok {
-					activatorhandler.DeleteRevisionHTTPMetrics(
+					activatorhandler.DeleteRevisionMetrics(
 						rev.Namespace,
 						rev.Labels[serving.ServiceLabelKey],
 						rev.Labels[serving.ConfigurationLabelKey],

--- a/cmd/activator/main.go
+++ b/cmd/activator/main.go
@@ -36,7 +36,9 @@ import (
 
 	// Injection related imports.
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/metric/noop"
 
+	"k8s.io/client-go/tools/cache"
 	netcfg "knative.dev/networking/pkg/config"
 	netprobe "knative.dev/networking/pkg/http/probe"
 	kubeclient "knative.dev/pkg/client/injection/kube/client"
@@ -47,6 +49,7 @@ import (
 	pkglogging "knative.dev/pkg/logging"
 	"knative.dev/pkg/logging/logkey"
 	pkgnet "knative.dev/pkg/network"
+	pkgmetrics "knative.dev/pkg/observability/metrics"
 	k8sruntime "knative.dev/pkg/observability/runtime/k8s"
 	"knative.dev/pkg/signals"
 	"knative.dev/pkg/system"
@@ -58,13 +61,17 @@ import (
 	activatorhandler "knative.dev/serving/pkg/activator/handler"
 	activatornet "knative.dev/serving/pkg/activator/net"
 	apiconfig "knative.dev/serving/pkg/apis/config"
+	"knative.dev/serving/pkg/apis/serving"
+	v1 "knative.dev/serving/pkg/apis/serving/v1"
 	asmetrics "knative.dev/serving/pkg/autoscaler/metrics"
+	revisioninformer "knative.dev/serving/pkg/client/injection/informers/serving/v1/revision"
 	pkghttp "knative.dev/serving/pkg/http"
 	"knative.dev/serving/pkg/http/handler"
 	"knative.dev/serving/pkg/logging"
 	"knative.dev/serving/pkg/networking"
 	o11yconfigmap "knative.dev/serving/pkg/observability/configmap"
 	"knative.dev/serving/pkg/observability/otel"
+	"knative.dev/pkg/kmeta"
 )
 
 const (
@@ -135,6 +142,12 @@ func main() {
 	pprof := k8sruntime.NewProfilingServer(logger.Named("pprof"))
 
 	mp, tp := otel.SetupObservabilityOrDie(ctx, "activator", logger, pprof)
+
+	obsCfg, err := otel.GetObservabilityConfig(ctx)
+	if err != nil {
+		logger.Fatalw("Failed to read observability config", zap.Error(err))
+	}
+	usePrometheus := obsCfg.Metrics.Protocol == pkgmetrics.ProtocolPrometheus
 
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -228,7 +241,7 @@ func main() {
 
 	// Create activation handler chain
 	// Note: innermost handlers are specified first, ie. the last handler in the chain will be executed first
-	ah := activatorhandler.New(ctx, throttler, transport, networkConfig.EnableMeshPodAddressability, logger, tlsEnabled, tp)
+	ah := activatorhandler.New(ctx, throttler, transport, networkConfig.EnableMeshPodAddressability, logger, tlsEnabled, tp, usePrometheus)
 	ah = handler.NewTimeoutHandler(ah, "activator request timeout", func(r *http.Request) (time.Duration, time.Duration, time.Duration) {
 		if rev := activatorhandler.RevisionFrom(r.Context()); rev != nil {
 			responseStartTimeout := 0 * time.Second
@@ -256,15 +269,18 @@ func main() {
 
 	// NOTE: MetricHandler is being used as the outermost handler of the meaty bits. We're not interested in measuring
 	// the healthchecks or probes.
-	ah = activatorhandler.NewMetricAttributeHandler(env.PodName, ah)
+	ah = activatorhandler.NewMetricHandler(env.PodName, ah, usePrometheus)
 	// We need the context handler to run first so ctx gets the revision info.
 	ah = activatorhandler.WrapActivatorHandlerWithFullDuplex(ah, logger)
 	ah = activatorhandler.NewContextHandler(ctx, ah, configStore)
 
-	ah = otelhttp.NewHandler(ah, "handle",
-		otelhttp.WithTracerProvider(tp),
-		otelhttp.WithMeterProvider(mp),
-	)
+	otelOpts := []otelhttp.Option{otelhttp.WithTracerProvider(tp)}
+	if usePrometheus {
+		otelOpts = append(otelOpts, otelhttp.WithMeterProvider(noop.NewMeterProvider()))
+	} else {
+		otelOpts = append(otelOpts, otelhttp.WithMeterProvider(mp))
+	}
+	ah = otelhttp.NewHandler(ah, "handle", otelOpts...)
 
 	// Network probe handlers.
 	ah = &activatorhandler.ProbeHandler{NextHandler: ah}
@@ -273,6 +289,26 @@ func main() {
 	sigCtx := signals.NewContext()
 	hc := newHealthCheck(sigCtx, logger, statSink)
 	ah = &activatorhandler.HealthHandler{HealthCheck: hc, NextHandler: ah, Logger: logger}
+
+	if usePrometheus {
+		revisioninformer.Get(ctx).Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+			DeleteFunc: func(obj interface{}) {
+				acc, err := kmeta.DeletionHandlingAccessor(obj)
+				if err != nil {
+					logger.Warnw("Revision delete: failed to extract accessor", zap.Error(err))
+					return
+				}
+				if rev, ok := acc.(*v1.Revision); ok {
+					activatorhandler.DeleteRevisionHTTPMetrics(
+						rev.Namespace,
+						rev.Labels[serving.ServiceLabelKey],
+						rev.Labels[serving.ConfigurationLabelKey],
+						rev.Name,
+					)
+				}
+			},
+		})
+	}
 
 	// Watch the logging config map and dynamically update logging levels.
 	configMapWatcher.Watch(pkglogging.ConfigMapName(), pkglogging.UpdateLevelFromConfigMap(logger, atomicLevel, component))

--- a/cmd/autoscaler/main.go
+++ b/cmd/autoscaler/main.go
@@ -45,6 +45,7 @@ import (
 	"knative.dev/pkg/injection/sharedmain"
 	"knative.dev/pkg/leaderelection"
 	"knative.dev/pkg/logging"
+	pkgmetrics "knative.dev/pkg/observability/metrics"
 	k8sruntime "knative.dev/pkg/observability/runtime/k8s"
 	"knative.dev/pkg/signals"
 	"knative.dev/pkg/system"
@@ -144,8 +145,14 @@ func main() {
 		logger.Fatalw("Failed to construct network config", zap.Error(err))
 	}
 
+	obsCfg, err := otel.GetObservabilityConfig(ctx)
+	if err != nil {
+		logger.Fatalw("Failed to read observability config", zap.Error(err))
+	}
+	usePrometheus := obsCfg.Metrics.Protocol == pkgmetrics.ProtocolPrometheus
+
 	collector := asmetrics.NewMetricCollector(
-		statsScraperFactoryFunc(podLister, networkConfig.EnableMeshPodAddressability, networkConfig.MeshCompatibilityMode, mp), logger)
+		statsScraperFactoryFunc(podLister, networkConfig.EnableMeshPodAddressability, networkConfig.MeshCompatibilityMode, mp, usePrometheus), logger)
 
 	// Set up scalers.
 	multiScaler := scaling.NewMultiScaler(ctx.Done(),
@@ -274,7 +281,7 @@ func uniScalerFactoryFunc(
 	}
 }
 
-func statsScraperFactoryFunc(podLister corev1listers.PodLister, usePassthroughLb bool, meshMode netcfg.MeshCompatibilityMode, mp metric.MeterProvider) asmetrics.StatsScraperFactory {
+func statsScraperFactoryFunc(podLister corev1listers.PodLister, usePassthroughLb bool, meshMode netcfg.MeshCompatibilityMode, mp metric.MeterProvider, usePrometheus bool) asmetrics.StatsScraperFactory {
 	return func(metric *autoscalingv1alpha1.Metric, logger *zap.SugaredLogger) (asmetrics.StatsScraper, error) {
 		if metric.Spec.ScrapeTarget == "" {
 			return nil, nil
@@ -286,7 +293,7 @@ func statsScraperFactoryFunc(podLister corev1listers.PodLister, usePassthroughLb
 		}
 
 		podAccessor := resources.NewPodAccessor(podLister, metric.Namespace, revisionName)
-		return asmetrics.NewStatsScraper(metric, revisionName, podAccessor, usePassthroughLb, meshMode, logger, mp), nil
+		return asmetrics.NewStatsScraper(metric, revisionName, podAccessor, usePassthroughLb, meshMode, logger, mp, usePrometheus), nil
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0
 	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/prometheus/client_golang v1.23.2
 	github.com/tsenart/vegeta/v12 v12.13.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.64.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.64.0
@@ -122,7 +123,6 @@ require (
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.4 // indirect
 	github.com/prometheus/otlptranslator v1.0.0 // indirect

--- a/pkg/activator/handler/concurrency_reporter.go
+++ b/pkg/activator/handler/concurrency_reporter.go
@@ -75,6 +75,7 @@ func NewConcurrencyReporter(
 	podName string,
 	statCh chan []asmetrics.StatMessage,
 	mp metric.MeterProvider,
+	usePrometheus bool,
 ) *ConcurrencyReporter {
 	return &ConcurrencyReporter{
 		logger:  logging.FromContext(ctx),
@@ -83,7 +84,7 @@ func NewConcurrencyReporter(
 		rl:      revisioninformer.Get(ctx).Lister(),
 
 		stats:   make(map[types.NamespacedName]*revisionStats),
-		metrics: newMetrics(mp),
+		metrics: newMetrics(mp, usePrometheus),
 	}
 }
 
@@ -220,16 +221,20 @@ func (cr *ConcurrencyReporter) reportToMetricsBackend(key types.NamespacedName, 
 	configurationName := revision.Labels[serving.ConfigurationLabelKey]
 	serviceName := revision.Labels[serving.ServiceLabelKey]
 
-	cr.metrics.requestCC.Record(
-		context.Background(),
-		concurrency,
-		metric.WithAttributeSet(attribute.NewSet(
-			metrics.ServiceNameKey.With(serviceName),
-			metrics.ConfigurationNameKey.With(configurationName),
-			metrics.RevisionNameKey.With(revName),
-			metrics.K8sNamespaceKey.With(ns),
-		)),
-	)
+	if cr.metrics.usePrometheus {
+		requestConcurrency.WithLabelValues(ns, serviceName, configurationName, revName).Set(concurrency)
+	} else {
+		cr.metrics.requestCC.Record(
+			context.Background(),
+			concurrency,
+			metric.WithAttributeSet(attribute.NewSet(
+				metrics.ServiceNameKey.With(serviceName),
+				metrics.ConfigurationNameKey.With(configurationName),
+				metrics.RevisionNameKey.With(revName),
+				metrics.K8sNamespaceKey.With(ns),
+			)),
+		)
+	}
 }
 
 // Run runs until stopCh is closed and processes events on all incoming channels.

--- a/pkg/activator/handler/concurrency_reporter_test.go
+++ b/pkg/activator/handler/concurrency_reporter_test.go
@@ -619,7 +619,7 @@ func newTestReporter(t *testing.T) (*ConcurrencyReporter, context.Context, conte
 	// Buffered channel permits avoiding sending the test commands on the separate go routine
 	// simplifying main test process.
 	statCh := make(chan []asmetrics.StatMessage, 10)
-	return NewConcurrencyReporter(ctx, activatorPodName, statCh, provider), ctx, cancel, reader
+	return NewConcurrencyReporter(ctx, activatorPodName, statCh, provider, false), ctx, cancel, reader
 }
 
 func revisionInformer(ctx context.Context, revs ...*v1.Revision) {
@@ -638,7 +638,7 @@ func BenchmarkConcurrencyReporterHandler(b *testing.B) {
 
 	// Buffer equal to the activator.
 	statCh := make(chan []asmetrics.StatMessage)
-	cr := NewConcurrencyReporter(ctx, activatorPodName, statCh, nil)
+	cr := NewConcurrencyReporter(ctx, activatorPodName, statCh, nil, false)
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)
@@ -708,7 +708,7 @@ func BenchmarkConcurrencyReporterReport(b *testing.B) {
 
 			// Different to the activator but doesn't matter as it isn't used in the test.
 			statCh := make(chan []asmetrics.StatMessage, revs)
-			cr := NewConcurrencyReporter(ctx, activatorPodName, statCh, nil)
+			cr := NewConcurrencyReporter(ctx, activatorPodName, statCh, nil, false)
 
 			fake := fakeservingclient.Get(ctx)
 			revisions := fakerevisioninformer.Get(ctx)

--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -95,7 +95,7 @@ func New(_ context.Context,
 
 	if usePrometheus {
 		transportOpts = append(transportOpts, otelhttp.WithMeterProvider(noop.NewMeterProvider()))
-		registerPromHTTPMetrics()
+		registerPromMetrics()
 	}
 
 	transport = otelhttp.NewTransport(transport, transportOpts...)

--- a/pkg/activator/handler/handler.go
+++ b/pkg/activator/handler/handler.go
@@ -24,10 +24,12 @@ import (
 	"net/http/httputil"
 	"strconv"
 	"strings"
+	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/trace"
 
 	"go.uber.org/zap"
@@ -40,6 +42,7 @@ import (
 	pkghandler "knative.dev/pkg/network/handlers"
 	"knative.dev/serving/pkg/activator"
 	apiconfig "knative.dev/serving/pkg/apis/config"
+	"knative.dev/serving/pkg/apis/serving"
 	pkghttp "knative.dev/serving/pkg/http"
 	"knative.dev/serving/pkg/networking"
 	"knative.dev/serving/pkg/queue"
@@ -71,16 +74,15 @@ func New(_ context.Context,
 	logger *zap.SugaredLogger,
 	tlsEnabled bool,
 	tp trace.TracerProvider,
+	usePrometheus bool,
 ) http.Handler {
 	if tp == nil {
 		tp = otel.GetTracerProvider()
 	}
 
-	transport = otelhttp.NewTransport(
-		transport,
+	transportOpts := []otelhttp.Option{
 		otelhttp.WithTracerProvider(tp),
 		otelhttp.WithFilter(func(r *http.Request) bool {
-			// Don't trace kubelet probes
 			return !network.IsKubeletProbe(r)
 		}),
 		otelhttp.WithSpanNameFormatter(func(operation string, r *http.Request) string {
@@ -89,7 +91,18 @@ func New(_ context.Context,
 			}
 			return fmt.Sprintf("%s %s", r.Method, r.URL.Path)
 		}),
-	)
+	}
+
+	if usePrometheus {
+		transportOpts = append(transportOpts, otelhttp.WithMeterProvider(noop.NewMeterProvider()))
+		registerPromHTTPMetrics()
+	}
+
+	transport = otelhttp.NewTransport(transport, transportOpts...)
+
+	if usePrometheus {
+		transport = &promClientMetricTransport{base: transport}
+	}
 
 	tracer := tp.Tracer("knative.dev/serving/pkg/activator")
 
@@ -183,4 +196,44 @@ func WrapActivatorHandlerWithFullDuplex(h http.Handler, logger *zap.SugaredLogge
 		}
 		h.ServeHTTP(w, r)
 	})
+}
+
+// promClientMetricTransport wraps an http.RoundTripper and records
+// client-side HTTP metrics to Prometheus histograms.
+type promClientMetricTransport struct {
+	base http.RoundTripper
+}
+
+func (t *promClientMetricTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	start := time.Now()
+	resp, err := t.base.RoundTrip(r)
+
+	rev := RevisionFrom(r.Context())
+	if rev == nil {
+		return resp, err
+	}
+
+	ns := rev.Namespace
+	svc := rev.Labels[serving.ServiceLabelKey]
+	cfg := rev.Labels[serving.ConfigurationLabelKey]
+	revName := rev.Name
+
+	method := standardizeMethod(r.Method)
+	protoName, protoVersion := protoInfo(r.Proto)
+	scheme := urlScheme(r.URL != nil && r.URL.Scheme == "https")
+
+	statusCode := "0"
+	if resp != nil {
+		statusCode = strconv.Itoa(resp.StatusCode)
+	}
+
+	// Label order must match httpMetricLabels in metrics.go
+	labels := []string{method, statusCode, protoName, protoVersion, scheme, ns, svc, cfg, revName}
+
+	clientRequestDuration.WithLabelValues(labels...).Observe(time.Since(start).Seconds())
+	if r.ContentLength >= 0 {
+		clientRequestBodySize.WithLabelValues(labels...).Observe(float64(r.ContentLength))
+	}
+
+	return resp, err
 }

--- a/pkg/activator/handler/handler_test.go
+++ b/pkg/activator/handler/handler_test.go
@@ -122,7 +122,7 @@ func TestActivationHandler(t *testing.T) {
 			ctx, cancel, _ := rtesting.SetupFakeContextWithCancel(t)
 			defer cancel()
 			handler := New(ctx, test.throttler, rt, false, /*usePassthroughLb*/
-				logging.FromContext(ctx), false /* TLS */, nil /* trace provider */)
+				logging.FromContext(ctx), false /* TLS */, nil /* trace provider */, false)
 
 			resp := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
@@ -162,7 +162,7 @@ func TestActivationHandlerProxyHeader(t *testing.T) {
 	defer cancel()
 
 	handler := New(ctx, fakeThrottler{}, rt, false, /*usePassthroughLb*/
-		logging.FromContext(ctx), false /* TLS */, nil /* trace provider */)
+		logging.FromContext(ctx), false /* TLS */, nil /* trace provider */, false)
 
 	writer := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
@@ -196,7 +196,7 @@ func TestActivationHandlerPassthroughLb(t *testing.T) {
 	defer cancel()
 
 	handler := New(ctx, fakeThrottler{}, rt, true, /*usePassthroughLb*/
-		logging.FromContext(ctx), false /* TLS */, nil /* trace provider */)
+		logging.FromContext(ctx), false /* TLS */, nil /* trace provider */, false)
 
 	writer := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
@@ -242,7 +242,7 @@ func TestActivationHandlerTraceSpans(t *testing.T) {
 		cancel()
 	}()
 
-	handler := New(ctx, fakeThrottler{}, rt, false /*usePassthroughLb*/, logging.FromContext(ctx), false /* TLS */, tp)
+	handler := New(ctx, fakeThrottler{}, rt, false /*usePassthroughLb*/, logging.FromContext(ctx), false /* TLS */, tp, false)
 
 	// Set up config store to populate context.
 	configStore := setupConfigStore(t, logging.FromContext(ctx))
@@ -306,7 +306,7 @@ func BenchmarkHandler(b *testing.B) {
 			}, nil
 		})
 
-		handler := New(ctx, fakeThrottler{}, rt, false /*usePassthroughLb*/, logging.FromContext(ctx), false /* TLS */, nil)
+		handler := New(ctx, fakeThrottler{}, rt, false /*usePassthroughLb*/, logging.FromContext(ctx), false /* TLS */, nil, false)
 
 		request := func() *http.Request {
 			req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)

--- a/pkg/activator/handler/main_test.go
+++ b/pkg/activator/handler/main_test.go
@@ -86,11 +86,11 @@ func BenchmarkHandlerChain(b *testing.B) {
 	})
 
 	// Make sure to update this if the activator's main file changes.
-	ah := New(ctx, fakeThrottler{}, rt, false, logger, false /* TLS */, tp)
+	ah := New(ctx, fakeThrottler{}, rt, false, logger, false /* TLS */, tp, false)
 	ah = concurrencyReporter.Handler(ah)
 	ah = NewTracingAttributeHandler(tp, ah)
 	ah, _ = pkghttp.NewRequestLogHandler(ah, io.Discard, "", nil, false)
-	ah = NewMetricAttributeHandler(activatorPodName, ah)
+	ah = NewMetricHandler(activatorPodName, ah, false)
 	ah = NewContextHandler(ctx, ah, configStore)
 	ah = &ProbeHandler{NextHandler: ah}
 	ah = netprobe.NewHandler(ah)
@@ -206,7 +206,7 @@ func TestActivatorChainHandlerWithFullDuplex(t *testing.T) {
 	ah = concurrencyReporter.Handler(proxyWithMiddleware)
 	ah = NewTracingAttributeHandler(tp, ah)
 	ah, _ = pkghttp.NewRequestLogHandler(ah, io.Discard, "", nil, false)
-	ah = NewMetricAttributeHandler(activatorPodName, ah)
+	ah = NewMetricHandler(activatorPodName, ah, false)
 	ah = WrapActivatorHandlerWithFullDuplex(ah, logger)
 	ah = NewContextHandler(ctx, ah, configStore)
 	ah = &ProbeHandler{NextHandler: ah}

--- a/pkg/activator/handler/main_test.go
+++ b/pkg/activator/handler/main_test.go
@@ -63,7 +63,7 @@ func BenchmarkHandlerChain(b *testing.B) {
 
 	// Buffer equal to the activator.
 	statCh := make(chan []asmetrics.StatMessage)
-	concurrencyReporter := NewConcurrencyReporter(ctx, activatorPodName, statCh, mp)
+	concurrencyReporter := NewConcurrencyReporter(ctx, activatorPodName, statCh, mp, false)
 	go concurrencyReporter.Run(ctx.Done())
 
 	// Just read and ignore all stat messages.
@@ -160,7 +160,7 @@ func TestActivatorChainHandlerWithFullDuplex(t *testing.T) {
 
 	// Buffer equal to the activator.
 	statCh := make(chan []asmetrics.StatMessage)
-	concurrencyReporter := NewConcurrencyReporter(ctx, activatorPodName, statCh, mp)
+	concurrencyReporter := NewConcurrencyReporter(ctx, activatorPodName, statCh, mp, false)
 	go concurrencyReporter.Run(ctx.Done())
 
 	// Just read and ignore all stat messages.

--- a/pkg/activator/handler/metric_handler.go
+++ b/pkg/activator/handler/metric_handler.go
@@ -18,34 +18,50 @@ package handler
 
 import (
 	"net/http"
+	"strconv"
+	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"knative.dev/serving/pkg/apis/serving"
+	pkghttp "knative.dev/serving/pkg/http"
 	"knative.dev/serving/pkg/metrics"
 )
 
-// NewMetricAttributeHandler creates a handler that adds serving attributes
-// to the otelhttp labeler
-func NewMetricAttributeHandler(podName string, next http.Handler) *MetricHandler {
+// NewMetricHandler creates a handler that either adds serving attributes
+// to the otelhttp labeler (OTel path) or records server-side HTTP metrics
+// directly to Prometheus histograms (Prometheus path).
+func NewMetricHandler(podName string, next http.Handler, usePrometheus bool) *MetricHandler {
+	if usePrometheus {
+		registerPromHTTPMetrics()
+	}
 	return &MetricHandler{
-		nextHandler: next,
-		podName:     podName,
+		nextHandler:   next,
+		podName:       podName,
+		usePrometheus: usePrometheus,
 	}
 }
 
 // MetricHandler is a handler that records request metrics.
 type MetricHandler struct {
-	podName     string
-	nextHandler http.Handler
+	podName       string
+	nextHandler   http.Handler
+	usePrometheus bool
 }
 
 func (h *MetricHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if h.usePrometheus {
+		h.serveHTTPPrometheus(w, r)
+	} else {
+		h.serveHTTPOTel(w, r)
+	}
+}
+
+func (h *MetricHandler) serveHTTPOTel(w http.ResponseWriter, r *http.Request) {
 	rev := RevisionFrom(r.Context())
 
 	serviceName := rev.Labels[serving.ServiceLabelKey]
 	configurationName := rev.Labels[serving.ConfigurationLabelKey]
 
-	// otelhttp middleware creates the labeler
 	labeler, _ := otelhttp.LabelerFromContext(r.Context())
 	labeler.Add(
 		metrics.ServiceNameKey.With(serviceName),
@@ -55,4 +71,70 @@ func (h *MetricHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	)
 
 	h.nextHandler.ServeHTTP(w, r)
+}
+
+func (h *MetricHandler) serveHTTPPrometheus(w http.ResponseWriter, r *http.Request) {
+	rev := RevisionFrom(r.Context())
+
+	svc := rev.Labels[serving.ServiceLabelKey]
+	cfg := rev.Labels[serving.ConfigurationLabelKey]
+	ns := rev.Namespace
+	revName := rev.Name
+
+	method := standardizeMethod(r.Method)
+	protoName, protoVersion := protoInfo(r.Proto)
+	scheme := urlScheme(r.TLS != nil)
+
+	rr := pkghttp.NewResponseRecorder(w, http.StatusOK)
+	start := time.Now()
+
+	defer func() {
+		duration := time.Since(start).Seconds()
+		statusCode := strconv.Itoa(rr.ResponseCode)
+
+		// Label order must match httpMetricLabels in metrics.go:
+		// http_request_method, http_response_status_code,
+		// network_protocol_name, network_protocol_version, url_scheme,
+		// k8s_namespace_name, kn_service_name, kn_configuration_name, kn_revision_name
+		labels := []string{method, statusCode, protoName, protoVersion, scheme, ns, svc, cfg, revName}
+
+		serverRequestDuration.WithLabelValues(labels...).Observe(duration)
+		if r.ContentLength >= 0 {
+			serverRequestBodySize.WithLabelValues(labels...).Observe(float64(r.ContentLength))
+		}
+		serverResponseBodySize.WithLabelValues(labels...).Observe(float64(rr.ResponseSize))
+	}()
+
+	h.nextHandler.ServeHTTP(rr, r)
+}
+
+func standardizeMethod(method string) string {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut,
+		http.MethodPatch, http.MethodDelete, http.MethodConnect,
+		http.MethodOptions, http.MethodTrace:
+		return method
+	default:
+		return "_OTHER"
+	}
+}
+
+func protoInfo(proto string) (name, version string) {
+	switch proto {
+	case "HTTP/1.0":
+		return "http", "1.0"
+	case "HTTP/1.1":
+		return "http", "1.1"
+	case "HTTP/2.0", "HTTP/2":
+		return "http", "2"
+	default:
+		return "", ""
+	}
+}
+
+func urlScheme(tls bool) string {
+	if tls {
+		return "https"
+	}
+	return "http"
 }

--- a/pkg/activator/handler/metric_handler.go
+++ b/pkg/activator/handler/metric_handler.go
@@ -32,7 +32,7 @@ import (
 // directly to Prometheus histograms (Prometheus path).
 func NewMetricHandler(podName string, next http.Handler, usePrometheus bool) *MetricHandler {
 	if usePrometheus {
-		registerPromHTTPMetrics()
+		registerPromMetrics()
 	}
 	return &MetricHandler{
 		nextHandler:   next,

--- a/pkg/activator/handler/metric_handler_test.go
+++ b/pkg/activator/handler/metric_handler_test.go
@@ -64,7 +64,7 @@ func TestRequestMetricHandler(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.label, func(t *testing.T) {
-			handler := NewMetricAttributeHandler(testPod, test.baseHandler)
+			handler := NewMetricHandler(testPod, test.baseHandler, false)
 
 			labeler := &otelhttp.Labeler{}
 
@@ -120,7 +120,7 @@ func BenchmarkMetricHandler(b *testing.B) {
 
 	reqCtx = otelhttp.ContextWithLabeler(reqCtx, &otelhttp.Labeler{})
 
-	handler := NewMetricAttributeHandler("benchPod", baseHandler)
+	handler := NewMetricHandler("benchPod", baseHandler, false)
 
 	resp := httptest.NewRecorder()
 	b.Run("sequential", func(b *testing.B) {

--- a/pkg/activator/handler/metrics.go
+++ b/pkg/activator/handler/metrics.go
@@ -27,22 +27,26 @@ import (
 var scopeName = "knative.dev/serving/pkg/activator"
 
 type ccMetrics struct {
-	requestCC metric.Float64Gauge
+	requestCC     metric.Float64Gauge
+	usePrometheus bool
 }
 
-func newMetrics(mp metric.MeterProvider) *ccMetrics {
-	var (
-		m        ccMetrics
-		err      error
-		provider = mp
-	)
+func newMetrics(mp metric.MeterProvider, usePrometheus bool) *ccMetrics {
+	m := ccMetrics{usePrometheus: usePrometheus}
 
+	if usePrometheus {
+		registerPromMetrics()
+		return &m
+	}
+
+	provider := mp
 	if provider == nil {
 		provider = otel.GetMeterProvider()
 	}
 
 	meter := provider.Meter(scopeName)
 
+	var err error
 	m.requestCC, err = meter.Float64Gauge(
 		"kn.revision.request.concurrency",
 		metric.WithDescription("Concurrent requests that are routed to Activator"),
@@ -56,7 +60,7 @@ func newMetrics(mp metric.MeterProvider) *ccMetrics {
 }
 
 var (
-	promHTTPRegisterOnce sync.Once
+	promRegisterOnce sync.Once
 
 	durationBuckets = []float64{0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10}
 
@@ -74,15 +78,23 @@ var (
 		"kn_revision_name",
 	}
 
+	concurrencyLabels = []string{
+		"k8s_namespace_name",
+		"kn_service_name",
+		"kn_configuration_name",
+		"kn_revision_name",
+	}
+
 	serverRequestDuration  *prometheus.HistogramVec
 	serverRequestBodySize  *prometheus.HistogramVec
 	serverResponseBodySize *prometheus.HistogramVec
 	clientRequestDuration  *prometheus.HistogramVec
 	clientRequestBodySize  *prometheus.HistogramVec
+	requestConcurrency     *prometheus.GaugeVec
 )
 
-func registerPromHTTPMetrics() {
-	promHTTPRegisterOnce.Do(func() {
+func registerPromMetrics() {
+	promRegisterOnce.Do(func() {
 		serverRequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "http_server_request_duration_seconds",
 			Help:    "Duration of HTTP server requests.",
@@ -113,27 +125,24 @@ func registerPromHTTPMetrics() {
 			Buckets: prometheus.ExponentialBuckets(1, 2, 21),
 		}, httpMetricLabels)
 
+		requestConcurrency = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "kn_revision_request_concurrency",
+			Help: "Concurrent requests that are routed to Activator.",
+		}, concurrencyLabels)
+
 		prometheus.MustRegister(
 			serverRequestDuration,
 			serverRequestBodySize,
 			serverResponseBodySize,
 			clientRequestDuration,
 			clientRequestBodySize,
+			requestConcurrency,
 		)
 	})
 }
 
-// revisionLabels are the labels used for DeletePartialMatch when cleaning up
-// metrics for a deleted revision.
-var revisionLabels = []string{
-	"k8s_namespace_name",
-	"kn_service_name",
-	"kn_configuration_name",
-	"kn_revision_name",
-}
-
-// DeleteRevisionHTTPMetrics removes all HTTP metrics associated with the given revision.
-func DeleteRevisionHTTPMetrics(namespace, serviceName, configName, revisionName string) {
+// DeleteRevisionMetrics removes all metrics associated with the given revision.
+func DeleteRevisionMetrics(namespace, serviceName, configName, revisionName string) {
 	labels := prometheus.Labels{
 		"k8s_namespace_name":    namespace,
 		"kn_service_name":       serviceName,
@@ -145,4 +154,5 @@ func DeleteRevisionHTTPMetrics(namespace, serviceName, configName, revisionName 
 	serverResponseBodySize.DeletePartialMatch(labels)
 	clientRequestDuration.DeletePartialMatch(labels)
 	clientRequestBodySize.DeletePartialMatch(labels)
+	requestConcurrency.DeletePartialMatch(labels)
 }

--- a/pkg/activator/handler/metrics.go
+++ b/pkg/activator/handler/metrics.go
@@ -17,6 +17,9 @@ limitations under the License.
 package handler
 
 import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
 )
@@ -50,4 +53,96 @@ func newMetrics(mp metric.MeterProvider) *ccMetrics {
 	}
 
 	return &m
+}
+
+var (
+	promHTTPRegisterOnce sync.Once
+
+	durationBuckets = []float64{0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10}
+
+	// Labels match the OTel-to-Prometheus naming convention (dots → underscores)
+	// used by the v1.21 otelhttp metrics.
+	httpMetricLabels = []string{
+		"http_request_method",
+		"http_response_status_code",
+		"network_protocol_name",
+		"network_protocol_version",
+		"url_scheme",
+		"k8s_namespace_name",
+		"kn_service_name",
+		"kn_configuration_name",
+		"kn_revision_name",
+	}
+
+	serverRequestDuration  *prometheus.HistogramVec
+	serverRequestBodySize  *prometheus.HistogramVec
+	serverResponseBodySize *prometheus.HistogramVec
+	clientRequestDuration  *prometheus.HistogramVec
+	clientRequestBodySize  *prometheus.HistogramVec
+)
+
+func registerPromHTTPMetrics() {
+	promHTTPRegisterOnce.Do(func() {
+		serverRequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "http_server_request_duration_seconds",
+			Help:    "Duration of HTTP server requests.",
+			Buckets: durationBuckets,
+		}, httpMetricLabels)
+
+		serverRequestBodySize = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "http_server_request_body_size_bytes",
+			Help:    "Size of HTTP server request bodies.",
+			Buckets: prometheus.ExponentialBuckets(1, 2, 21),
+		}, httpMetricLabels)
+
+		serverResponseBodySize = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "http_server_response_body_size_bytes",
+			Help:    "Size of HTTP server response bodies.",
+			Buckets: prometheus.ExponentialBuckets(1, 2, 21),
+		}, httpMetricLabels)
+
+		clientRequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "http_client_request_duration_seconds",
+			Help:    "Duration of HTTP client requests.",
+			Buckets: durationBuckets,
+		}, httpMetricLabels)
+
+		clientRequestBodySize = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "http_client_request_body_size_bytes",
+			Help:    "Size of HTTP client request bodies.",
+			Buckets: prometheus.ExponentialBuckets(1, 2, 21),
+		}, httpMetricLabels)
+
+		prometheus.MustRegister(
+			serverRequestDuration,
+			serverRequestBodySize,
+			serverResponseBodySize,
+			clientRequestDuration,
+			clientRequestBodySize,
+		)
+	})
+}
+
+// revisionLabels are the labels used for DeletePartialMatch when cleaning up
+// metrics for a deleted revision.
+var revisionLabels = []string{
+	"k8s_namespace_name",
+	"kn_service_name",
+	"kn_configuration_name",
+	"kn_revision_name",
+}
+
+// DeleteRevisionHTTPMetrics removes all HTTP metrics associated with the given revision.
+func DeleteRevisionHTTPMetrics(namespace, serviceName, configName, revisionName string) {
+	labels := prometheus.Labels{
+		"k8s_namespace_name":    namespace,
+		"kn_service_name":       serviceName,
+		"kn_configuration_name": configName,
+		"kn_revision_name":      revisionName,
+	}
+	serverRequestDuration.DeletePartialMatch(labels)
+	serverRequestBodySize.DeletePartialMatch(labels)
+	serverResponseBodySize.DeletePartialMatch(labels)
+	clientRequestDuration.DeletePartialMatch(labels)
+	clientRequestBodySize.DeletePartialMatch(labels)
 }

--- a/pkg/activator/handler/metrics.go
+++ b/pkg/activator/handler/metrics.go
@@ -64,6 +64,9 @@ var (
 
 	durationBuckets = []float64{0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10}
 
+	// OTel SDK default histogram boundaries (reader.go DefaultAggregationSelector for InstrumentKindHistogram).
+	bodySizeBuckets = []float64{0, 5, 10, 25, 50, 75, 100, 250, 500, 750, 1000, 2500, 5000, 7500, 10000}
+
 	// Labels match the OTel-to-Prometheus naming convention (dots → underscores)
 	// used by the v1.21 otelhttp metrics.
 	httpMetricLabels = []string{
@@ -104,13 +107,13 @@ func registerPromMetrics() {
 		serverRequestBodySize = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "http_server_request_body_size_bytes",
 			Help:    "Size of HTTP server request bodies.",
-			Buckets: prometheus.ExponentialBuckets(1, 2, 21),
+			Buckets: bodySizeBuckets,
 		}, httpMetricLabels)
 
 		serverResponseBodySize = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "http_server_response_body_size_bytes",
 			Help:    "Size of HTTP server response bodies.",
-			Buckets: prometheus.ExponentialBuckets(1, 2, 21),
+			Buckets: bodySizeBuckets,
 		}, httpMetricLabels)
 
 		clientRequestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -122,7 +125,7 @@ func registerPromMetrics() {
 		clientRequestBodySize = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "http_client_request_body_size_bytes",
 			Help:    "Size of HTTP client request bodies.",
-			Buckets: prometheus.ExponentialBuckets(1, 2, 21),
+			Buckets: bodySizeBuckets,
 		}, httpMetricLabels)
 
 		requestConcurrency = prometheus.NewGaugeVec(prometheus.GaugeOpts{

--- a/pkg/autoscaler/metrics/collector.go
+++ b/pkg/autoscaler/metrics/collector.go
@@ -343,6 +343,9 @@ func newCollection(metric *autoscalingv1alpha1.Metric, scraper StatsScraper, clo
 func (c *collection) close() {
 	close(c.stopCh)
 	c.grp.Wait()
+	if closer, ok := c.getScraper().(interface{ Close() }); ok {
+		closer.Close()
+	}
 }
 
 // updateMetric safely updates the metric stored in the collection.

--- a/pkg/autoscaler/metrics/stats_scraper.go
+++ b/pkg/autoscaler/metrics/stats_scraper.go
@@ -27,8 +27,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric"
+	otelmetric "go.opentelemetry.io/otel/metric"
 
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
@@ -74,6 +75,9 @@ var (
 	errPodsExhausted              = errors.New("pods exhausted")
 
 	latencyBounds = []float64{0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10}
+
+	promRegisterOnce sync.Once
+	scrapeDuration   *prometheus.HistogramVec
 )
 
 // StatsScraper defines the interface for collecting Revision metrics
@@ -136,15 +140,24 @@ type serviceScraper struct {
 
 	host   string
 	url    string
-	attrs  attribute.Set
 	logger *zap.SugaredLogger
 
 	podAccessor      resources.PodAccessor
 	usePassthroughLb bool
 	podsAddressable  bool
 
-	duration metric.Float64Histogram
-	clock    clock.Clock
+	clock clock.Clock
+
+	// OTel path (non-Prometheus backends)
+	duration otelmetric.Float64Histogram
+	attrs    attribute.Set
+
+	// Prometheus path
+	usePrometheus bool
+	namespace     string
+	serviceName   string
+	configName    string
+	revisionName  string
 }
 
 // NewStatsScraper creates a new StatsScraper for the Revision which
@@ -156,11 +169,12 @@ func NewStatsScraper(
 	usePassthroughLb bool,
 	meshMode netcfg.MeshCompatibilityMode,
 	logger *zap.SugaredLogger,
-	mp metric.MeterProvider,
+	mp otelmetric.MeterProvider,
+	usePrometheus bool,
 ) StatsScraper {
 	directClient := newHTTPScrapeClient(client)
 	meshClient := newHTTPScrapeClient(noKeepaliveClient)
-	return newServiceScraperWithClient(metric, revisionName, podAccessor, usePassthroughLb, meshMode, directClient, meshClient, logger, mp)
+	return newServiceScraperWithClient(metric, revisionName, podAccessor, usePassthroughLb, meshMode, directClient, meshClient, logger, mp, usePrometheus)
 }
 
 func newServiceScraperWithClient(
@@ -171,23 +185,13 @@ func newServiceScraperWithClient(
 	meshMode netcfg.MeshCompatibilityMode,
 	directClient, meshClient scrapeClient,
 	logger *zap.SugaredLogger,
-	mp metric.MeterProvider,
+	mp otelmetric.MeterProvider,
+	usePrometheus bool,
 ) *serviceScraper {
 	svcName := m.Labels[serving.ServiceLabelKey]
 	cfgName := m.Labels[serving.ConfigurationLabelKey]
 
-	meter := mp.Meter(scopeName)
-	metric, err := meter.Float64Histogram(
-		"kn.autoscaler.scrape.duration",
-		metric.WithDescription("The duration of scraping the revision"),
-		metric.WithUnit("s"),
-		metric.WithExplicitBucketBoundaries(latencyBounds...),
-	)
-	if err != nil {
-		panic(err)
-	}
-
-	return &serviceScraper{
+	s := &serviceScraper{
 		meshMode:         meshMode,
 		directClient:     directClient,
 		meshClient:       meshClient,
@@ -198,14 +202,52 @@ func newServiceScraperWithClient(
 		usePassthroughLb: usePassthroughLb,
 		logger:           logger,
 		clock:            clock.RealClock{},
-		duration:         metric,
-		attrs: attribute.NewSet(
+		usePrometheus:    usePrometheus,
+		namespace:        m.ObjectMeta.Namespace,
+		serviceName:      svcName,
+		configName:       cfgName,
+		revisionName:     revisionName,
+	}
+
+	if usePrometheus {
+		promRegisterOnce.Do(func() {
+			scrapeDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+				Name:    "kn_autoscaler_scrape_duration_seconds",
+				Help:    "The duration of scraping the revision",
+				Buckets: latencyBounds,
+			}, []string{"namespace_name", "service_name", "configuration_name", "revision_name"})
+			prometheus.MustRegister(scrapeDuration)
+		})
+	} else {
+		meter := mp.Meter(scopeName)
+		h, err := meter.Float64Histogram(
+			"kn.autoscaler.scrape.duration",
+			otelmetric.WithDescription("The duration of scraping the revision"),
+			otelmetric.WithUnit("s"),
+			otelmetric.WithExplicitBucketBoundaries(latencyBounds...),
+		)
+		if err != nil {
+			panic(err)
+		}
+		s.duration = h
+		s.attrs = attribute.NewSet(
 			semconv.K8SNamespaceName(m.ObjectMeta.Namespace),
 			metrics.ServiceNameKey.With(svcName),
 			metrics.ConfigurationNameKey.With(cfgName),
 			// TODO: Re-enable when OTel has the ability to remove attributes
 			// metrics.RevisionNameKey.With(revisionName),
-		),
+		)
+	}
+
+	return s
+}
+
+// Close removes the scrape duration metric for this scraper's label set when
+// using Prometheus, preventing stale metrics from persisting after the revision
+// is deleted.
+func (s *serviceScraper) Close() {
+	if s.usePrometheus {
+		scrapeDuration.DeleteLabelValues(s.namespace, s.serviceName, s.configName, s.revisionName)
 	}
 }
 
@@ -226,8 +268,11 @@ func (s *serviceScraper) Scrape(window time.Duration) (stat Stat, err error) {
 			return
 		}
 		scrapeTime := s.clock.Since(startTime)
-		scrapeTimeSec := scrapeTime.Seconds()
-		s.duration.Record(context.Background(), scrapeTimeSec, metric.WithAttributeSet(s.attrs))
+		if s.usePrometheus {
+			scrapeDuration.WithLabelValues(s.namespace, s.serviceName, s.configName, s.revisionName).Observe(scrapeTime.Seconds())
+		} else {
+			s.duration.Record(context.Background(), scrapeTime.Seconds(), otelmetric.WithAttributeSet(s.attrs))
+		}
 	}()
 
 	switch s.meshMode {

--- a/pkg/autoscaler/metrics/stats_scraper_test.go
+++ b/pkg/autoscaler/metrics/stats_scraper_test.go
@@ -99,7 +99,7 @@ func TestNewServiceScraperWithClientHappyCase(t *testing.T) {
 	accessor := resources.NewPodAccessor(
 		fakepodsinformer.Get(ctx).Lister(),
 		testNamespace, testRevision)
-	sc := NewStatsScraper(metric, testRevision, accessor, false, netcfg.MeshCompatibilityModeAuto, logtesting.TestLogger(t), mp)
+	sc := NewStatsScraper(metric, testRevision, accessor, false, netcfg.MeshCompatibilityModeAuto, logtesting.TestLogger(t), mp, false)
 	if svcS, want := sc.(*serviceScraper), urlFromTarget(testRevision+"-zhudex", testNamespace); svcS.url != want {
 		t.Errorf("scraper.url = %s, want: %s", svcS.url, want)
 	}
@@ -802,7 +802,7 @@ func serviceScraperForTest(ctx context.Context, t *testing.T, meshMode netcfg.Me
 		fakepodsinformer.Get(ctx).Lister(),
 		testNamespace, testRevision)
 	logger := logtesting.TestLogger(t)
-	ss := newServiceScraperWithClient(metric, testRevision, accessor, usePassthroughLb, meshMode, directClient, meshClient, logger, mp)
+	ss := newServiceScraperWithClient(metric, testRevision, accessor, usePassthroughLb, meshMode, directClient, meshClient, logger, mp, false)
 	ss.podsAddressable = podsAddressable
 	return ss
 }


### PR DESCRIPTION
proof of concept for fixing SRVKS-1347 

Solving metrics leak by using prometheus API directly if prometheus is enabled (so that we can explicitly drop metrics when revisisons are deleted)