### PR TITLE
[release-v1.21] fix autoscaler stats_scraper metrics labels

### DIFF
--- a/pkg/autoscaler/metrics/stats_scraper.go
+++ b/pkg/autoscaler/metrics/stats_scraper.go
@@ -215,7 +215,7 @@ func newServiceScraperWithClient(
 				Name:    "kn_autoscaler_scrape_duration_seconds",
 				Help:    "The duration of scraping the revision",
 				Buckets: latencyBounds,
-			}, []string{"namespace_name", "service_name", "configuration_name", "revision_name"})
+			}, []string{"k8s_namespace_name", "kn_service_name", "kn_configuration_name", "kn_revision_name"})
 			prometheus.MustRegister(scrapeDuration)
 		})
 	} else {


### PR DESCRIPTION
Fixes our prometheus-specific hack labels

follow up from https://github.com/openshift-knative/serving/pull/1743 


